### PR TITLE
Add APIs for pipeline assessment

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
@@ -16,6 +16,8 @@
 
 package io.cdap.delta.api;
 
+import io.cdap.delta.api.assessment.TableRegistry;
+
 /**
  * Pluggable interface for reading change events
  */
@@ -37,4 +39,12 @@ public interface DeltaSource {
    * @return an event reader used to read change events
    */
   EventReader createReader(DeltaSourceContext context, EventEmitter eventEmitter);
+
+  /**
+   * Create a table registry that is used to fetch information about tables in databases.
+   *
+   * @param context program context
+   * @return table registry used to fetch information about tables in databases.
+   */
+  TableRegistry createTableRegistry(DeltaRuntimeContext context);
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaTarget.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaTarget.java
@@ -16,6 +16,8 @@
 
 package io.cdap.delta.api;
 
+import io.cdap.delta.api.assessment.TableAssessor;
+
 /**
  * A CDC target, responsible for writing data to a storage system.
  */
@@ -37,4 +39,13 @@ public interface DeltaTarget {
    * @throws Exception if the consumer could not be created, which will result in the program failure
    */
   EventConsumer createConsumer(DeltaTargetContext context) throws Exception;
+
+  /**
+   * Create a table assessor that will check if there will be potential problems replicating a table.
+   *
+   * @param context program context
+   * @return a table assessor
+   * @throws Exception if the table assessor could not be created
+   */
+  TableAssessor createTableAssessor(DeltaRuntimeContext context) throws Exception;
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/ColumnAssessment.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/ColumnAssessment.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.sql.SQLType;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Assessment of a column.
+ */
+public class ColumnAssessment {
+  private final String name;
+  private final SQLType type;
+  private final boolean supported;
+  private final ColumnSuggestion suggestion;
+
+  public ColumnAssessment(String name, SQLType type) {
+    this.name = name;
+    this.type = type;
+    this.supported = true;
+    this.suggestion = null;
+  }
+
+  public ColumnAssessment(String name, SQLType type, ColumnSuggestion suggestion) {
+    this.name = name;
+    this.type = type;
+    this.supported = false;
+    this.suggestion = suggestion;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public SQLType getType() {
+    return type;
+  }
+
+  public boolean isSupported() {
+    return supported;
+  }
+
+  @Nullable
+  public ColumnSuggestion getSuggestion() {
+    return suggestion;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ColumnAssessment that = (ColumnAssessment) o;
+    return supported == that.supported &&
+      Objects.equals(name, that.name) &&
+      Objects.equals(type, that.type) &&
+      Objects.equals(suggestion, that.suggestion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, supported, suggestion);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/ColumnDetail.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/ColumnDetail.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.sql.SQLType;
+import java.util.Objects;
+
+/**
+ * Details about a table column.
+ */
+public class ColumnDetail {
+  private final String name;
+  private final SQLType type;
+  private final boolean nullable;
+
+  public ColumnDetail(String name, SQLType type, boolean nullable) {
+    this.name = name;
+    this.type = type;
+    this.nullable = nullable;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public SQLType getType() {
+    return type;
+  }
+
+  public boolean isNullable() {
+    return nullable;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ColumnDetail that = (ColumnDetail) o;
+    return nullable == that.nullable &&
+      Objects.equals(name, that.name) &&
+      Objects.equals(type, that.type);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, nullable);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/ColumnSuggestion.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/ColumnSuggestion.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Suggestion for how to fix a column problem.
+ */
+public class ColumnSuggestion {
+  private final String message;
+  private final List<String> transforms;
+
+  public ColumnSuggestion(String message, List<String> transforms) {
+    this.message = message;
+    this.transforms = Collections.unmodifiableList(new ArrayList<>(transforms));
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public List<String> getTransforms() {
+    return transforms;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ColumnSuggestion that = (ColumnSuggestion) o;
+    return Objects.equals(message, that.message) &&
+      Objects.equals(transforms, that.transforms);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(message, transforms);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/PipelineAssessment.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/PipelineAssessment.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * An assessment about a potential pipeline, indicating possible errors and fixes for those errors.
+ */
+public class PipelineAssessment {
+  private final TableSummaryAssessment tables;
+  private final List<Problem> features;
+  private final List<Problem> connectivity;
+
+  public PipelineAssessment(TableSummaryAssessment tables,
+                            List<Problem> features,
+                            List<Problem> connectivity) {
+    this.tables = tables;
+    this.features = Collections.unmodifiableList(new ArrayList<>(features));
+    this.connectivity = Collections.unmodifiableList(new ArrayList<>(connectivity));
+  }
+
+  /**
+   * @return summary of issues related to tables
+   */
+  public TableSummaryAssessment getTables() {
+    return tables;
+  }
+
+  /**
+   * @return potential problems related to features
+   */
+  public List<Problem> getFeatures() {
+    return features;
+  }
+
+  /**
+   * @return potential problems related to connectivity
+   */
+  public List<Problem> getConnectivity() {
+    return connectivity;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PipelineAssessment that = (PipelineAssessment) o;
+    return Objects.equals(tables, that.tables) &&
+      Objects.equals(features, that.features) &&
+      Objects.equals(connectivity, that.connectivity);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tables, features, connectivity);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/Problem.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/Problem.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.util.Objects;
+
+/**
+ * An assessment about some type of entity.
+ */
+public class Problem {
+  private final String name;
+  private final String description;
+  private final String suggestion;
+  private final String impact;
+
+  public Problem(String name, String description, String suggestion, String impact) {
+    this.name = name;
+    this.description = description;
+    this.suggestion = suggestion;
+    this.impact = impact;
+  }
+
+  /**
+   * @return name of the entity that is being assessed
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return description of what might be wrong
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * @return suggestion for what to do next to fix the potential problem
+   */
+  public String getSuggestion() {
+    return suggestion;
+  }
+
+  /**
+   * @return impact of the potential problem
+   */
+  public String getImpact() {
+    return impact;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Problem that = (Problem) o;
+    return Objects.equals(name, that.name) &&
+      Objects.equals(description, that.description) &&
+      Objects.equals(suggestion, that.suggestion) &&
+      Objects.equals(impact, that.impact);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description, suggestion, impact);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableAssessment.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableAssessment.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A detailed assessment of issues related to a table.
+ */
+public class TableAssessment {
+  private final List<ColumnAssessment> columns;
+  private final List<Problem> features;
+  private final List<Problem> connectivity;
+
+  public TableAssessment(List<ColumnAssessment> columns,
+                         List<Problem> features,
+                         List<Problem> connectivity) {
+    this.columns = Collections.unmodifiableList(new ArrayList<>(columns));
+    this.features = Collections.unmodifiableList(new ArrayList<>(features));
+    this.connectivity = Collections.unmodifiableList(new ArrayList<>(connectivity));
+  }
+
+  public List<ColumnAssessment> getColumns() {
+    return columns;
+  }
+
+  public List<Problem> getFeatures() {
+    return features;
+  }
+
+  public List<Problem> getConnectivity() {
+    return connectivity;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TableAssessment that = (TableAssessment) o;
+    return Objects.equals(columns, that.columns) &&
+      Objects.equals(features, that.features) &&
+      Objects.equals(connectivity, that.connectivity);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(columns, features, connectivity);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableAssessor.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableAssessor.java
@@ -14,25 +14,19 @@
  * the License.
  */
 
-package io.cdap.delta.app.proto;
+package io.cdap.delta.api.assessment;
 
 /**
- * Represent a stage in the delta pipeline.
+ * Creates assessments, highlighting potential problems. This is used when a pipeline is being created to give
+ * users early feedback on configuration or environmental issues.
  */
-public class Stage {
-  private final String name;
-  private final Plugin plugin;
+public interface TableAssessor {
 
-  public Stage(String name, Plugin plugin) {
-    this.name = name;
-    this.plugin = plugin;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public Plugin getPlugin() {
-    return plugin;
-  }
+  /**
+   * Assess whether there will be potential problems replicating data from the specified table.
+   *
+   * @param tableDetail detail about the table to replicate
+   * @return assessment of potential problems
+   */
+  TableAssessment assess(TableDetail tableDetail);
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableDetail.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableDetail.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Detailed information about a table.
+ */
+public class TableDetail extends TableSummary {
+  private final List<String> primaryKey;
+  private final List<ColumnDetail> columns;
+
+  public TableDetail(String database, String table, List<String> primaryKey, List<ColumnDetail> columns) {
+    super(database, table, columns.size());
+    this.primaryKey = Collections.unmodifiableList(new ArrayList<>(primaryKey));
+    this.columns = Collections.unmodifiableList(new ArrayList<>(columns));
+  }
+
+  public List<String> getPrimaryKey() {
+    return primaryKey;
+  }
+
+  public List<ColumnDetail> getColumns() {
+    return columns;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    TableDetail that = (TableDetail) o;
+    return Objects.equals(primaryKey, that.primaryKey) &&
+      Objects.equals(columns, that.columns);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), primaryKey, columns);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableList.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableList.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A list of tables in a database.
+ */
+public class TableList {
+  private final List<TableSummary> tables;
+
+  public TableList(List<TableSummary> tables) {
+    this.tables = Collections.unmodifiableList(new ArrayList<>(tables));
+  }
+
+  public List<TableSummary> getTables() {
+    return tables;
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableNotFoundException.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableNotFoundException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+/**
+ * Thrown when a table is unexpectedly not found.
+ */
+public class TableNotFoundException extends Exception {
+
+  public TableNotFoundException(String database, String table, String errorMessage) {
+    super(String.format("Table '%s' in database '%s' was not found. %s", table, database, errorMessage));
+  }
+
+  public TableNotFoundException(String database, String table, String errorMessage, Throwable cause) {
+    super(String.format("Table '%s' in database '%s' was not found. %s", table, database, errorMessage), cause);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableRegistry.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableRegistry.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.io.IOException;
+
+/**
+ * Fetches information about tables in a database. The registry is used when a user is configuring a delta pipeline.
+ */
+public interface TableRegistry {
+
+  /**
+   * @return list of readable tables
+   * @throws IOException if the table information could not be read
+   */
+  TableList listTables() throws IOException;
+
+  /**
+   * Return details about a table.
+   *
+   * @param database name of the database that table resides in
+   * @param table the table name
+   * @return detail about the table
+   * @throws TableNotFoundException if the specified table does not exist
+   * @throws IOException if the table information could not be read
+   */
+  TableDetail describeTable(String database, String table) throws TableNotFoundException, IOException;
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableSummary.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableSummary.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+import java.util.Objects;
+
+/**
+ * Summary of information about a table.
+ */
+public class TableSummary {
+  private final String database;
+  private final String table;
+  private final int numColumns;
+
+  public TableSummary(String database, String table, int numColumns) {
+    this.database = database;
+    this.table = table;
+    this.numColumns = numColumns;
+  }
+
+  public String getDatabase() {
+    return database;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  public int getNumColumns() {
+    return numColumns;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TableSummary that = (TableSummary) o;
+    return numColumns == that.numColumns &&
+      Objects.equals(database, that.database) &&
+      Objects.equals(table, that.table);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(database, table, numColumns);
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableSummaryAssessment.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableSummaryAssessment.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api.assessment;
+
+/**
+ * A summary of potential issues about a table.
+ */
+public class TableSummaryAssessment extends TableSummary {
+  private final int numColumnsNotSupported;
+  private final int numColumnsPartiallySupported;
+
+  public TableSummaryAssessment(String database, String table, int numColumns, int numColumnsNotSupported,
+                                int numColumnsPartiallySupported) {
+    super(database, table, numColumns);
+    this.numColumnsNotSupported = numColumnsNotSupported;
+    this.numColumnsPartiallySupported = numColumnsPartiallySupported;
+  }
+
+  /**
+   * @return number of columns that are not supported
+   */
+  public int getNumColumnsNotSupported() {
+    return numColumnsNotSupported;
+  }
+
+  /**
+   * Number of partially supported columns. A partially supported column is something that can be replicated, but with
+   * some loss of data or change in structure. For example, precision in a date time may be lost,
+   * or a database specific type might be translated into a string.
+   *
+   * @return number of columns that are partially supported.
+   */
+  public int getNumColumnsPartiallySupported() {
+    return numColumnsPartiallySupported;
+  }
+}

--- a/delta-app/pom.xml
+++ b/delta-app/pom.xml
@@ -42,8 +42,19 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-system-app-api</artifactId>
+      <version>${cdap.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.delta</groupId>
       <artifactId>delta-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.delta</groupId>
+      <artifactId>delta-proto</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
@@ -21,9 +21,10 @@ import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.delta.api.Configurer;
 import io.cdap.delta.api.DeltaSource;
 import io.cdap.delta.api.DeltaTarget;
-import io.cdap.delta.app.proto.Connection;
-import io.cdap.delta.app.proto.DeltaConfig;
-import io.cdap.delta.app.proto.Stage;
+import io.cdap.delta.app.service.AssessmentService;
+import io.cdap.delta.proto.Connection;
+import io.cdap.delta.proto.DeltaConfig;
+import io.cdap.delta.proto.Stage;
 
 import java.util.List;
 
@@ -35,6 +36,11 @@ public class DeltaApp extends AbstractApplication<DeltaConfig> {
   @Override
   public void configure() {
     DeltaConfig conf = getConfig();
+
+    if (conf.isService()) {
+      addService(new AssessmentService());
+      return;
+    }
 
     List<Connection> connections = conf.getConnections();
     if (connections.size() != 1 || conf.getStages().size() != 2) {

--- a/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentHandler.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app.service;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.cdap.cdap.api.service.http.AbstractSystemHttpServiceHandler;
+import io.cdap.cdap.api.service.http.HttpServiceRequest;
+import io.cdap.cdap.api.service.http.HttpServiceResponder;
+import io.cdap.delta.api.assessment.ColumnAssessment;
+import io.cdap.delta.api.assessment.ColumnDetail;
+import io.cdap.delta.api.assessment.PipelineAssessment;
+import io.cdap.delta.api.assessment.TableAssessment;
+import io.cdap.delta.api.assessment.TableDetail;
+import io.cdap.delta.api.assessment.TableList;
+import io.cdap.delta.api.assessment.TableSummary;
+import io.cdap.delta.api.assessment.TableSummaryAssessment;
+import io.cdap.delta.proto.DraftList;
+
+import java.sql.JDBCType;
+import java.sql.SQLType;
+import java.util.Collections;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+/**
+ * Handler for storing drafts and performing assessments.
+ */
+public class AssessmentHandler extends AbstractSystemHttpServiceHandler {
+  private static final Gson GSON = new GsonBuilder()
+    .registerTypeAdapter(SQLType.class, new SQLTypeSerializer())
+    .setPrettyPrinting()
+    .create();
+
+  @GET
+  @Path("v1/contexts/{context}/drafts")
+  public void listDrafts(HttpServiceRequest request, HttpServiceResponder responder,
+                         @PathParam("context") String namespace) {
+    responder.sendJson(new DraftList(Collections.emptyList()));
+  }
+
+  @GET
+  @Path("v1/contexts/{context}/drafts/{draft}")
+  public void getDraft(HttpServiceRequest request, HttpServiceResponder responder,
+                       @PathParam("context") String namespace,
+                       @PathParam("draft") String draftName) {
+    responder.sendStatus(404);
+  }
+
+  @PUT
+  @Path("v1/contexts/{context}/drafts/{draft}")
+  public void putDraft(HttpServiceRequest request, HttpServiceResponder responder,
+                       @PathParam("context") String namespace,
+                       @PathParam("draft") String draftName) {
+    responder.sendStatus(200);
+  }
+
+  @POST
+  @Path("v1/contexts/{context}/drafts/{draft}/listTables")
+  public void listDraftTables(HttpServiceRequest request, HttpServiceResponder responder,
+                              @PathParam("context") String namespace,
+                              @PathParam("draft") String draftName) {
+    responder.sendString(GSON.toJson(new TableList(Collections.singletonList(new TableSummary("db", "table", 1)))));
+  }
+
+  @POST
+  @Path("v1/contexts/{context}/databases/{database}/tables/{table}/describe")
+  public void describeTable(HttpServiceRequest request, HttpServiceResponder responder,
+                            @PathParam("context") String namespace,
+                            @PathParam("database") String database,
+                            @PathParam("table") String table) {
+    responder.sendString(
+      GSON.toJson(new TableDetail("db", "table",
+                                  Collections.singletonList("id"),
+                                  Collections.singletonList(new ColumnDetail("id", JDBCType.VARCHAR, false)))));
+  }
+
+  @POST
+  @Path("v1/contexts/{context}/drafts/{draft}/assess")
+  public void assessDraft(HttpServiceRequest request, HttpServiceResponder responder,
+                          @PathParam("context") String namespace,
+                          @PathParam("draft") String draftName) {
+    responder.sendString(GSON.toJson(new PipelineAssessment(new TableSummaryAssessment("db", "table", 1, 0, 0),
+                                                            Collections.emptyList(),
+                                                            Collections.emptyList())));
+  }
+
+  @POST
+  @Path("v1/contexts/{context}/databases/{database}/tables/{table}/assess")
+  public void assessTable(HttpServiceRequest request, HttpServiceResponder responder,
+                          @PathParam("context") String namespace,
+                          @PathParam("database") String database,
+                          @PathParam("table") String table) {
+    responder.sendString(
+      GSON.toJson(new TableAssessment(Collections.singletonList(new ColumnAssessment("id", JDBCType.VARCHAR)),
+                                      Collections.emptyList(),
+                                      Collections.emptyList())));
+  }
+}

--- a/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentService.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentService.java
@@ -14,26 +14,19 @@
  * the License.
  */
 
-package io.cdap.delta.app.proto;
+package io.cdap.delta.app.service;
+
+import io.cdap.cdap.api.service.AbstractSystemService;
 
 /**
- *
- * A connection.
+ * System service for storing drafts and performing assessments.
  */
-public class Connection {
-  private final String from;
-  private final String to;
+public class AssessmentService extends AbstractSystemService {
+  static final String NAME = "assessor";
 
-  public Connection(String from, String to) {
-    this.from = from;
-    this.to = to;
-  }
-
-  public String getFrom() {
-    return from;
-  }
-
-  public String getTo() {
-    return to;
+  @Override
+  protected void configure() {
+    setName(NAME);
+    addHandler(new AssessmentHandler());
   }
 }

--- a/delta-app/src/main/java/io/cdap/delta/app/service/SQLTypeSerializer.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/service/SQLTypeSerializer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app.service;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.sql.SQLType;
+
+/**
+ * Serializes SQLType into a user friendly name.
+ */
+public class SQLTypeSerializer implements JsonSerializer<SQLType> {
+
+  @Override
+  public JsonElement serialize(SQLType sqlType, Type type, JsonSerializationContext jsonSerializationContext) {
+    return new JsonPrimitive(sqlType.getName());
+  }
+}

--- a/delta-proto/pom.xml
+++ b/delta-proto/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2020 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.cdap.delta</groupId>
+    <artifactId>delta</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>delta-proto</artifactId>
+  <name>Delta Proto Objects</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${cdap.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.delta</groupId>
+      <artifactId>delta-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/delta-proto/src/main/java/io/cdap/delta/proto/Artifact.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/Artifact.java
@@ -14,39 +14,31 @@
  * the License.
  */
 
-package io.cdap.delta.app.proto;
-
-import java.util.Map;
+package io.cdap.delta.proto;
 
 /**
- * Represents a plugin
+ * An artifact.
  */
-public class Plugin {
+public class Artifact {
   private final String name;
-  private final String type;
-  private final Map<String, String> properties;
-  private final Artifact artifact;
+  private final String version;
+  private final String scope;
 
-  public Plugin(String name, String type, Map<String, String> properties, Artifact artifact) {
+  public Artifact(String name, String version, String scope) {
     this.name = name;
-    this.type = type;
-    this.properties = properties;
-    this.artifact = artifact;
+    this.version = version;
+    this.scope = scope;
   }
 
   public String getName() {
     return name;
   }
 
-  public String getType() {
-    return type;
+  public String getVersion() {
+    return version;
   }
 
-  public Map<String, String> getProperties() {
-    return properties;
-  }
-
-  public Artifact getArtifact() {
-    return artifact;
+  public String getScope() {
+    return scope;
   }
 }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/Connection.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/Connection.java
@@ -14,31 +14,26 @@
  * the License.
  */
 
-package io.cdap.delta.app.proto;
+package io.cdap.delta.proto;
 
 /**
- * An artifact.
+ *
+ * A connection.
  */
-public class Artifact {
-  private final String name;
-  private final String version;
-  private final String scope;
+public class Connection {
+  private final String from;
+  private final String to;
 
-  public Artifact(String name, String version, String scope) {
-    this.name = name;
-    this.version = version;
-    this.scope = scope;
+  public Connection(String from, String to) {
+    this.from = from;
+    this.to = to;
   }
 
-  public String getName() {
-    return name;
+  public String getFrom() {
+    return from;
   }
 
-  public String getVersion() {
-    return version;
-  }
-
-  public String getScope() {
-    return scope;
+  public String getTo() {
+    return to;
   }
 }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/DeltaConfig.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/DeltaConfig.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package io.cdap.delta.app.proto;
+package io.cdap.delta.proto;
 
 import io.cdap.cdap.api.Config;
 import io.cdap.cdap.api.Resources;
@@ -31,6 +31,7 @@ public class DeltaConfig extends Config {
   private final List<Connection> connections;
   private final Resources resources;
   private final String offsetBasePath;
+  private final boolean service;
 
   public DeltaConfig(Stage source, Stage target) {
     this(source, target, null, null);
@@ -41,6 +42,7 @@ public class DeltaConfig extends Config {
     this.connections = Collections.singletonList(new Connection(source.getName(), target.getName()));
     this.resources = resources;
     this.offsetBasePath = offsetBasePath;
+    this.service = false;
   }
 
   public List<Stage> getStages() {
@@ -57,5 +59,9 @@ public class DeltaConfig extends Config {
 
   public Resources getResources() {
     return resources == null ? new Resources(8192, 4) : resources;
+  }
+
+  public boolean isService() {
+    return service;
   }
 }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/DraftList.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/DraftList.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * List of drafts.
+ */
+public class DraftList {
+  private final List<DeltaConfig> drafts;
+
+  public DraftList(List<DeltaConfig> drafts) {
+    this.drafts = Collections.unmodifiableList(new ArrayList<>(drafts));
+  }
+
+  public List<DeltaConfig> getDrafts() {
+    return drafts;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DraftList draftList = (DraftList) o;
+    return Objects.equals(drafts, draftList.drafts);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(drafts);
+  }
+}

--- a/delta-proto/src/main/java/io/cdap/delta/proto/Plugin.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/Plugin.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import java.util.Map;
+
+/**
+ * Represents a plugin
+ */
+public class Plugin {
+  private final String name;
+  private final String type;
+  private final Map<String, String> properties;
+  private final Artifact artifact;
+
+  public Plugin(String name, String type, Map<String, String> properties, Artifact artifact) {
+    this.name = name;
+    this.type = type;
+    this.properties = properties;
+    this.artifact = artifact;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public Map<String, String> getProperties() {
+    return properties;
+  }
+
+  public Artifact getArtifact() {
+    return artifact;
+  }
+}

--- a/delta-proto/src/main/java/io/cdap/delta/proto/Stage.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/Stage.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+/**
+ * Represent a stage in the delta pipeline.
+ */
+public class Stage {
+  private final String name;
+  private final Plugin plugin;
+
+  public Stage(String name, Plugin plugin) {
+    this.name = name;
+    this.plugin = plugin;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Plugin getPlugin() {
+    return plugin;
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
   <modules>
     <module>delta-api</module>
     <module>delta-app</module>
+    <module>delta-proto</module>
   </modules>
 
   <dependencies>


### PR DESCRIPTION
Added a system service that will be used to store pipeline drafts
and perform assessments on those drafts.

Refactored some classes into a delta-proto module that contains
objects used in the RESTful APIs. Also introduced assessments to
the API module, and modified the source and target APIs. Sources
are now responsible for generating a list of tables and fetching
details about each table. Targets are now responsible for assessing
whether there will be problems replicating a given table.