### PR TITLE
add storage for pipeline drafts

### DIFF
--- a/delta-app/pom.xml
+++ b/delta-app/pom.xml
@@ -48,6 +48,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-system-app-unit-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.cdap.delta</groupId>
       <artifactId>delta-api</artifactId>
       <version>${project.version}</version>
@@ -55,6 +61,11 @@
     <dependency>
       <groupId>io.cdap.delta</groupId>
       <artifactId>delta-proto</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.delta</groupId>
+      <artifactId>delta-storage</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
@@ -39,6 +39,7 @@ public class DeltaApp extends AbstractApplication<DeltaConfig> {
 
     if (conf.isService()) {
       addService(new AssessmentService());
+      setDescription("Delta Pipeline System Service");
       return;
     }
 
@@ -67,6 +68,12 @@ public class DeltaApp extends AbstractApplication<DeltaConfig> {
     target.configure(configurer);
 
     addWorker(new DeltaWorker(sourceConf.getName(), targetConf.getName(), conf.getOffsetBasePath()));
+
+    String description = conf.getDescription();
+    if (description == null) {
+      description = String.format("%s to %s", sourceConf.getName(), targetConf.getName());
+    }
+    setDescription(description);
   }
 
   private <T> T registerPlugin(Stage stageConf) {

--- a/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentService.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentService.java
@@ -17,6 +17,7 @@
 package io.cdap.delta.app.service;
 
 import io.cdap.cdap.api.service.AbstractSystemService;
+import io.cdap.delta.store.DraftStore;
 
 /**
  * System service for storing drafts and performing assessments.
@@ -28,5 +29,6 @@ public class AssessmentService extends AbstractSystemService {
   protected void configure() {
     setName(NAME);
     addHandler(new AssessmentHandler());
+    createTable(DraftStore.TABLE_SPEC);
   }
 }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/Artifact.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/Artifact.java
@@ -16,6 +16,8 @@
 
 package io.cdap.delta.proto;
 
+import java.util.Objects;
+
 /**
  * An artifact.
  */
@@ -40,5 +42,24 @@ public class Artifact {
 
   public String getScope() {
     return scope;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Artifact artifact = (Artifact) o;
+    return Objects.equals(name, artifact.name) &&
+      Objects.equals(version, artifact.version) &&
+      Objects.equals(scope, artifact.scope);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, version, scope);
   }
 }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/DeltaConfig.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/DeltaConfig.java
@@ -22,11 +22,14 @@ import io.cdap.cdap.api.Resources;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Config for a Delta app.
  */
 public class DeltaConfig extends Config {
+  private final String description;
   private final List<Stage> stages;
   private final List<Connection> connections;
   private final Resources resources;
@@ -38,11 +41,17 @@ public class DeltaConfig extends Config {
   }
 
   public DeltaConfig(Stage source, Stage target, Resources resources, String offsetBasePath) {
+    this.description = "";
     this.stages = Collections.unmodifiableList(Arrays.asList(source, target));
     this.connections = Collections.singletonList(new Connection(source.getName(), target.getName()));
     this.resources = resources;
     this.offsetBasePath = offsetBasePath;
     this.service = false;
+  }
+
+  @Nullable
+  public String getDescription() {
+    return description;
   }
 
   public List<Stage> getStages() {
@@ -63,5 +72,27 @@ public class DeltaConfig extends Config {
 
   public boolean isService() {
     return service;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeltaConfig config = (DeltaConfig) o;
+    return service == config.service &&
+      Objects.equals(description, config.description) &&
+      Objects.equals(stages, config.stages) &&
+      Objects.equals(connections, config.connections) &&
+      Objects.equals(resources, config.resources) &&
+      Objects.equals(offsetBasePath, config.offsetBasePath);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(description, stages, connections, resources, offsetBasePath, service);
   }
 }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/Plugin.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/Plugin.java
@@ -17,6 +17,7 @@
 package io.cdap.delta.proto;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Represents a plugin
@@ -48,5 +49,25 @@ public class Plugin {
 
   public Artifact getArtifact() {
     return artifact;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Plugin plugin = (Plugin) o;
+    return Objects.equals(name, plugin.name) &&
+      Objects.equals(type, plugin.type) &&
+      Objects.equals(properties, plugin.properties) &&
+      Objects.equals(artifact, plugin.artifact);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, type, properties, artifact);
   }
 }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/Stage.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/Stage.java
@@ -16,6 +16,8 @@
 
 package io.cdap.delta.proto;
 
+import java.util.Objects;
+
 /**
  * Represent a stage in the delta pipeline.
  */
@@ -34,5 +36,23 @@ public class Stage {
 
   public Plugin getPlugin() {
     return plugin;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Stage stage = (Stage) o;
+    return Objects.equals(name, stage.name) &&
+      Objects.equals(plugin, stage.plugin);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, plugin);
   }
 }

--- a/delta-storage/pom.xml
+++ b/delta-storage/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright © 2020 Cask Data, Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.cdap.delta</groupId>
+    <artifactId>delta</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>delta-storage</artifactId>
+  <name>Delta pipeline storage</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-api</artifactId>
+      <version>${cdap.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-system-app-api</artifactId>
+      <version>${cdap.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.cdap</groupId>
+      <artifactId>cdap-system-app-unit-test</artifactId>
+      <version>${cdap.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.delta</groupId>
+      <artifactId>delta-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.cdap.delta</groupId>
+      <artifactId>delta-proto</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/delta-storage/src/main/java/io/cdap/delta/store/Draft.java
+++ b/delta-storage/src/main/java/io/cdap/delta/store/Draft.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.store;
+
+import io.cdap.delta.proto.DeltaConfig;
+
+import java.util.Objects;
+
+/**
+ * A pipeline draft.
+ */
+public class Draft {
+  private final DeltaConfig config;
+  private final long createdTimeMillis;
+  private final long updatedTimeMillis;
+
+  public Draft(DeltaConfig config, long createdTimeMillis, long updatedTimeMillis) {
+    this.config = config;
+    this.createdTimeMillis = createdTimeMillis;
+    this.updatedTimeMillis = updatedTimeMillis;
+  }
+
+  public DeltaConfig getConfig() {
+    return config;
+  }
+
+  public long getCreatedTimeMillis() {
+    return createdTimeMillis;
+  }
+
+  public long getUpdatedTimeMillis() {
+    return updatedTimeMillis;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Draft draft = (Draft) o;
+    return createdTimeMillis == draft.createdTimeMillis &&
+      updatedTimeMillis == draft.updatedTimeMillis &&
+      Objects.equals(config, draft.config);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(config, createdTimeMillis, updatedTimeMillis);
+  }
+}

--- a/delta-storage/src/main/java/io/cdap/delta/store/DraftId.java
+++ b/delta-storage/src/main/java/io/cdap/delta/store/DraftId.java
@@ -14,29 +14,28 @@
  * the License.
  */
 
-package io.cdap.delta.proto;
+package io.cdap.delta.store;
 
 import java.util.Objects;
 
 /**
- *
- * A connection.
+ * Uniquely identifies a draft.
  */
-public class Connection {
-  private final String from;
-  private final String to;
+public class DraftId {
+  private final Namespace namespace;
+  private final String name;
 
-  public Connection(String from, String to) {
-    this.from = from;
-    this.to = to;
+  public DraftId(Namespace namespace, String name) {
+    this.namespace = namespace;
+    this.name = name;
   }
 
-  public String getFrom() {
-    return from;
+  public Namespace getNamespace() {
+    return namespace;
   }
 
-  public String getTo() {
-    return to;
+  public String getName() {
+    return name;
   }
 
   @Override
@@ -47,13 +46,13 @@ public class Connection {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Connection that = (Connection) o;
-    return Objects.equals(from, that.from) &&
-      Objects.equals(to, that.to);
+    DraftId draftId = (DraftId) o;
+    return Objects.equals(namespace, draftId.namespace) &&
+      Objects.equals(name, draftId.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(from, to);
+    return Objects.hash(namespace, name);
   }
 }

--- a/delta-storage/src/main/java/io/cdap/delta/store/DraftStore.java
+++ b/delta-storage/src/main/java/io/cdap/delta/store/DraftStore.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.store;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.dataset.lib.CloseableIterator;
+import io.cdap.cdap.spi.data.StructuredRow;
+import io.cdap.cdap.spi.data.StructuredTable;
+import io.cdap.cdap.spi.data.StructuredTableContext;
+import io.cdap.cdap.spi.data.TableNotFoundException;
+import io.cdap.cdap.spi.data.table.StructuredTableId;
+import io.cdap.cdap.spi.data.table.StructuredTableSpecification;
+import io.cdap.cdap.spi.data.table.field.Field;
+import io.cdap.cdap.spi.data.table.field.FieldType;
+import io.cdap.cdap.spi.data.table.field.Fields;
+import io.cdap.cdap.spi.data.table.field.Range;
+import io.cdap.delta.proto.DeltaConfig;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Stores pipeline drafts.
+ */
+public class DraftStore {
+  private static final Gson GSON = new Gson();
+  private static final StructuredTableId TABLE_ID = new StructuredTableId("delta_drafts");
+  private static final String NAMESPACE_COL = "namespace";
+  private static final String GENERATION_COL = "generation";
+  private static final String NAME_COL = "name";
+  private static final String CREATED_COL = "created";
+  private static final String UPDATED_COL = "updated";
+  private static final String CONFIG_COL = "config";
+  public static final StructuredTableSpecification TABLE_SPEC = new StructuredTableSpecification.Builder()
+    .withId(TABLE_ID)
+    .withFields(new FieldType(NAMESPACE_COL, FieldType.Type.STRING),
+                new FieldType(GENERATION_COL, FieldType.Type.LONG),
+                new FieldType(NAME_COL, FieldType.Type.STRING),
+                new FieldType(CREATED_COL, FieldType.Type.LONG),
+                new FieldType(UPDATED_COL, FieldType.Type.LONG),
+                new FieldType(CONFIG_COL, FieldType.Type.BYTES))
+    .withPrimaryKeys(NAMESPACE_COL, GENERATION_COL, NAME_COL)
+    .build();
+
+  private final StructuredTable table;
+
+  DraftStore(StructuredTable table) {
+    this.table = table;
+  }
+
+  public static DraftStore get(StructuredTableContext context) {
+    try {
+      StructuredTable table = context.getTable(TABLE_ID);
+      return new DraftStore(table);
+    } catch (TableNotFoundException e) {
+      throw new IllegalStateException(String.format(
+        "System table '%s' does not exist. Please check your system environment.", TABLE_ID.getName()), e);
+    }
+  }
+
+  public List<Draft> listDrafts(Namespace namespace) throws IOException {
+    List<Field<?>> prefix = new ArrayList<>(2);
+    prefix.add(Fields.stringField(NAMESPACE_COL, namespace.getName()));
+    prefix.add(Fields.longField(GENERATION_COL, namespace.getGeneration()));
+    Range range = Range.singleton(prefix);
+    List<Draft> results = new ArrayList<>();
+    try (CloseableIterator<StructuredRow> rowIter = table.scan(range, Integer.MAX_VALUE)) {
+      while (rowIter.hasNext()) {
+        results.add(fromRow(rowIter.next()));
+      }
+    }
+    return results;
+  }
+
+  public Optional<Draft> getDraft(DraftId id) throws IOException {
+    Optional<StructuredRow> row = table.read(getKey(id));
+    return row.map(this::fromRow);
+  }
+
+  public void deleteDraft(DraftId id) throws IOException {
+    table.delete(getKey(id));
+  }
+
+  public void writeDraft(DraftId id, DeltaConfig config) throws IOException {
+    Optional<Draft> existing = getDraft(id);
+    long now = System.currentTimeMillis();
+    long createTime = existing.map(Draft::getCreatedTimeMillis).orElse(now);
+    long updatedTime = existing.map(Draft::getCreatedTimeMillis).orElse(now);
+    table.upsert(getRow(id, new Draft(config, createTime, updatedTime)));
+  }
+
+  private void addKeyFields(DraftId id, List<Field<?>> fields) {
+    fields.add(Fields.stringField(NAMESPACE_COL, id.getNamespace().getName()));
+    fields.add(Fields.longField(GENERATION_COL, id.getNamespace().getGeneration()));
+    fields.add(Fields.stringField(NAME_COL, id.getName()));
+  }
+
+  private List<Field<?>> getKey(DraftId id) {
+    List<Field<?>> keyFields = new ArrayList<>(3);
+    addKeyFields(id, keyFields);
+    return keyFields;
+  }
+
+  private List<Field<?>> getRow(DraftId id, Draft draft) {
+    List<Field<?>> fields = new ArrayList<>(6);
+    addKeyFields(id, fields);
+    fields.add(Fields.longField(CREATED_COL, draft.getCreatedTimeMillis()));
+    fields.add(Fields.longField(UPDATED_COL, draft.getUpdatedTimeMillis()));
+    fields.add(Fields.bytesField(CONFIG_COL, GSON.toJson(draft.getConfig()).getBytes(StandardCharsets.UTF_8)));
+    return fields;
+  }
+
+  @SuppressWarnings("ConstantConditions")
+  private Draft fromRow(StructuredRow row) {
+    long createTime = row.getLong(CREATED_COL);
+    long updateTime = row.getLong(UPDATED_COL);
+    String configStr = new String(row.getBytes(CONFIG_COL), StandardCharsets.UTF_8);
+    DeltaConfig config = GSON.fromJson(configStr, DeltaConfig.class);
+    return new Draft(config, createTime, updateTime);
+  }
+}

--- a/delta-storage/src/main/java/io/cdap/delta/store/Namespace.java
+++ b/delta-storage/src/main/java/io/cdap/delta/store/Namespace.java
@@ -14,29 +14,28 @@
  * the License.
  */
 
-package io.cdap.delta.proto;
+package io.cdap.delta.store;
 
 import java.util.Objects;
 
 /**
- *
- * A connection.
+ * A namespace name and generation.
  */
-public class Connection {
-  private final String from;
-  private final String to;
+public class Namespace {
+  private final String name;
+  private final long generation;
 
-  public Connection(String from, String to) {
-    this.from = from;
-    this.to = to;
+  public Namespace(String name, long generation) {
+    this.name = name;
+    this.generation = generation;
   }
 
-  public String getFrom() {
-    return from;
+  public String getName() {
+    return name;
   }
 
-  public String getTo() {
-    return to;
+  public long getGeneration() {
+    return generation;
   }
 
   @Override
@@ -47,13 +46,13 @@ public class Connection {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    Connection that = (Connection) o;
-    return Objects.equals(from, that.from) &&
-      Objects.equals(to, that.to);
+    Namespace namespace = (Namespace) o;
+    return generation == namespace.generation &&
+      Objects.equals(name, namespace.name);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(from, to);
+    return Objects.hash(name, generation);
   }
 }

--- a/delta-storage/src/test/java/io/cdap/delta/store/DraftStoreTest.java
+++ b/delta-storage/src/test/java/io/cdap/delta/store/DraftStoreTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.store;
+
+import io.cdap.cdap.common.conf.Constants;
+import io.cdap.cdap.spi.data.transaction.TransactionException;
+import io.cdap.cdap.test.SystemAppTestBase;
+import io.cdap.cdap.test.TestConfiguration;
+import io.cdap.delta.api.DeltaSource;
+import io.cdap.delta.api.DeltaTarget;
+import io.cdap.delta.proto.Artifact;
+import io.cdap.delta.proto.DeltaConfig;
+import io.cdap.delta.proto.Plugin;
+import io.cdap.delta.proto.Stage;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Tests for DraftStore
+ */
+public class DraftStoreTest extends SystemAppTestBase {
+
+  @ClassRule
+  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
+
+  @Before
+  public void setupTest() throws Exception {
+    getStructuredTableAdmin().create(DraftStore.TABLE_SPEC);
+  }
+
+  @After
+  public void cleanupTest() throws Exception {
+    getStructuredTableAdmin().drop(DraftStore.TABLE_SPEC.getTableId());
+  }
+
+  @Test
+  public void testGetNothing() throws Exception {
+    getTransactionRunner().run(context -> {
+      DraftStore store = DraftStore.get(context);
+
+      Namespace namespace = new Namespace("ns", 0L);
+      Assert.assertFalse(store.getDraft(new DraftId(namespace, "abc")).isPresent());
+      Assert.assertTrue(store.listDrafts(namespace).isEmpty());
+    });
+  }
+
+  @Test
+  public void testCRUD() throws TransactionException {
+    Namespace ns1 = new Namespace("n0", 10L);
+    DraftId id1 = new DraftId(ns1, "abc");
+    DeltaConfig config1 = new DeltaConfig(new Stage("src", new Plugin("mysql", DeltaSource.PLUGIN_TYPE,
+                                                                      Collections.singletonMap("k1", "v1"),
+                                                                      new Artifact("plugins", "1.0.0", "SYSTEM"))),
+                                          new Stage("target", new Plugin("bq", DeltaTarget.PLUGIN_TYPE,
+                                                                         Collections.singletonMap("k2", "v2"),
+                                                                         new Artifact("plugins", "1.0.0", "SYSTEM"))));
+    DraftId id2 = new DraftId(ns1, "xyz");
+    DeltaConfig config2 = new DeltaConfig(new Stage("src", new Plugin("oracle", DeltaSource.PLUGIN_TYPE,
+                                                                      Collections.singletonMap("k1", "v1"),
+                                                                      new Artifact("plugins", "1.0.0", "SYSTEM"))),
+                                          new Stage("target", new Plugin("bq", DeltaTarget.PLUGIN_TYPE,
+                                                                         Collections.singletonMap("k2", "v2"),
+                                                                         new Artifact("plugins", "1.0.0", "SYSTEM"))));
+    Namespace ns2 = new Namespace("n1", 10L);
+    DraftId id3 = new DraftId(ns2, "xyz");
+    DeltaConfig config3 = new DeltaConfig(new Stage("src", new Plugin("sqlserver", DeltaSource.PLUGIN_TYPE,
+                                                                      Collections.singletonMap("k1", "v1"),
+                                                                      new Artifact("plugins", "1.0.0", "SYSTEM"))),
+                                          new Stage("target", new Plugin("bq", DeltaTarget.PLUGIN_TYPE,
+                                                                         Collections.singletonMap("k2", "v2"),
+                                                                         new Artifact("plugins", "1.0.0", "SYSTEM"))));
+
+    // write all 3 drafts
+    getTransactionRunner().run(context -> {
+      DraftStore store = DraftStore.get(context);
+      store.writeDraft(id1, config1);
+      store.writeDraft(id2, config2);
+      store.writeDraft(id3, config3);
+    });
+
+    // test get and list
+    getTransactionRunner().run(context -> {
+      DraftStore store = DraftStore.get(context);
+
+      Optional<Draft> draft = store.getDraft(id1);
+      Assert.assertTrue(draft.isPresent());
+      Assert.assertEquals(config1, draft.get().getConfig());
+
+      draft = store.getDraft(id2);
+      Assert.assertTrue(draft.isPresent());
+      Assert.assertEquals(config2, draft.get().getConfig());
+
+      draft = store.getDraft(id3);
+      Assert.assertTrue(draft.isPresent());
+      Assert.assertEquals(config3, draft.get().getConfig());
+
+      List<Draft> drafts = store.listDrafts(ns1);
+      Assert.assertEquals(2, drafts.size());
+      Iterator<Draft> draftIter = drafts.iterator();
+      Assert.assertEquals(config1, draftIter.next().getConfig());
+      Assert.assertEquals(config2, draftIter.next().getConfig());
+
+      drafts = store.listDrafts(ns2);
+      Assert.assertEquals(1, drafts.size());
+      draftIter = drafts.iterator();
+      Assert.assertEquals(config3, draftIter.next().getConfig());
+    });
+
+    // delete draft3
+    getTransactionRunner().run(context -> {
+      DraftStore store = DraftStore.get(context);
+      store.deleteDraft(id3);
+    });
+
+    // test get and list for draft3 returns nothing
+    getTransactionRunner().run(context -> {
+      DraftStore store = DraftStore.get(context);
+
+      Assert.assertFalse(store.getDraft(id3).isPresent());
+      Assert.assertTrue(store.listDrafts(ns2).isEmpty());
+    });
+  }
+
+  @Test
+  public void testNamespaceGenerations() throws TransactionException {
+    Namespace ns1 = new Namespace("ns", 1L);
+    Namespace ns2 = new Namespace(ns1.getName(), ns1.getGeneration() + 1L);
+
+    DraftId id1 = new DraftId(ns1, "abc");
+    DraftId id2 = new DraftId(ns2, id1.getName());
+    DeltaConfig config1 = new DeltaConfig(new Stage("src", new Plugin("mysql", DeltaSource.PLUGIN_TYPE,
+                                                                      Collections.singletonMap("k1", "v1"),
+                                                                      new Artifact("plugins", "1.0.0", "SYSTEM"))),
+                                          new Stage("target", new Plugin("bq", DeltaTarget.PLUGIN_TYPE,
+                                                                         Collections.singletonMap("k2", "v2"),
+                                                                         new Artifact("plugins", "1.0.0", "SYSTEM"))));
+    DeltaConfig config2 = new DeltaConfig(new Stage("src", new Plugin("oracle", DeltaSource.PLUGIN_TYPE,
+                                                                      Collections.singletonMap("k1", "v1"),
+                                                                      new Artifact("plugins", "1.0.0", "SYSTEM"))),
+                                          new Stage("target", new Plugin("bq", DeltaTarget.PLUGIN_TYPE,
+                                                                         Collections.singletonMap("k2", "v2"),
+                                                                         new Artifact("plugins", "1.0.0", "SYSTEM"))));
+
+    // test drafts in one generation aren't visible in other gen
+    getTransactionRunner().run(context -> {
+      DraftStore store = DraftStore.get(context);
+
+      store.writeDraft(id1, config1);
+      store.writeDraft(id2, config2);
+    });
+
+    getTransactionRunner().run(context -> {
+      DraftStore store = DraftStore.get(context);
+
+      Optional<Draft> draft = store.getDraft(id1);
+      Assert.assertTrue(draft.isPresent());
+      Assert.assertEquals(config1, draft.get().getConfig());
+
+      draft = store.getDraft(id2);
+      Assert.assertTrue(draft.isPresent());
+      Assert.assertEquals(config2, draft.get().getConfig());
+
+      List<Draft> drafts = store.listDrafts(ns1);
+      Assert.assertEquals(1, drafts.size());
+      Assert.assertEquals(config1, drafts.iterator().next().getConfig());
+
+      drafts = store.listDrafts(ns2);
+      Assert.assertEquals(1, drafts.size());
+      Assert.assertEquals(config2, drafts.iterator().next().getConfig());
+    });
+  }
+
+}
+

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
     <module>delta-api</module>
     <module>delta-app</module>
     <module>delta-proto</module>
+    <module>delta-storage</module>
   </modules>
 
   <dependencies>


### PR DESCRIPTION
Added a draft store and real implementation for service endpoints
related to storing and fetching drafts. The store was added in a
separate module to avoid conflicts in Hadoop classes used by the
CDAP test framework and HDFS client used by the app.