### PR TITLE
cleanup restful APIs

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -117,6 +117,18 @@ public class DraftService {
   }
 
   /**
+   * Delete the given draft.
+   *
+   * @param draftId id of the draft to delete
+   */
+  public void deleteDraft(DraftId draftId) {
+    TransactionRunners.run(txRunner, context -> {
+      DraftStore draftStore = DraftStore.get(context);
+      draftStore.deleteDraft(draftId);
+    });
+  }
+
+  /**
    * List the database tables readable by the source in the given draft id. An instance of the plugin will be
    * instantiated in order to generate this list. This is an expensive operation.
    *

--- a/delta-proto/src/main/java/io/cdap/delta/proto/DBTable.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/DBTable.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import java.util.Objects;
+
+/**
+ * A database and a table.
+ */
+public class DBTable {
+  private final String database;
+  private final String table;
+
+  public DBTable(String database, String table) {
+    this.database = database;
+    this.table = table;
+  }
+
+  public String getDatabase() {
+    return database;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  /**
+   * Validates that both database and table are non-null and non-empty. This is required when the object is created
+   * by deserializing user provided input.
+   */
+  public void validate() {
+    if (database == null || database.isEmpty()) {
+      throw new IllegalArgumentException("The database is not specified. Please specify a database.");
+    }
+    if (table == null || table.isEmpty()) {
+      throw new IllegalArgumentException("The table is not specified. Please specify a table.");
+    }
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DBTable dbTable = (DBTable) o;
+    return Objects.equals(database, dbTable.database) &&
+      Objects.equals(table, dbTable.table);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(database, table);
+  }
+}


### PR DESCRIPTION
Removed database and table names from the path of the describe
table and assess table endpoints. Instead, the database and table
names are passed in through the request body.

This change was made because these endpoints are actions to perform
using a draft, and not elements within a draft.
It also makes the API more extensible in case there needs to be
additional information passed in the future.