### PR TITLE
tweak the standardize API to take the full table detail as input

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableRegistry.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableRegistry.java
@@ -16,11 +16,8 @@
 
 package io.cdap.delta.api.assessment;
 
-import io.cdap.cdap.api.data.schema.Schema;
-
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.List;
 
 /**
  * Fetches information about tables in a database. The registry is used when a user is configuring a delta pipeline.
@@ -51,5 +48,5 @@ public interface TableRegistry extends Closeable {
    * @param tableDetail raw table descriptor
    * @return standardized table descriptor
    */
-  Schema standardizeSchema(List<ColumnDetail> tableDetail);
+  StandardizedTableDetail standardize(TableDetail tableDetail);
 }

--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -288,9 +288,7 @@ public class DraftService {
     TableDetail filteredDetail = new TableDetail(db, table, detail.getPrimaryKey(), selectedColumns);
     TableAssessment srcAssessment = sourceTableAssessor.assess(filteredDetail);
 
-    Schema standardSchema = tableRegistry.standardizeSchema(filteredDetail.getColumns());
-    StandardizedTableDetail standardizedDetail = new StandardizedTableDetail(db, table, detail.getPrimaryKey(),
-                                                                             standardSchema);
+    StandardizedTableDetail standardizedDetail = tableRegistry.standardize(filteredDetail);
     TableAssessment targetAssessment = targetTableAssesor.assess(standardizedDetail);
 
     return merge(srcAssessment, targetAssessment);

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockSource.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockSource.java
@@ -34,6 +34,7 @@ import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.EventReader;
 import io.cdap.delta.api.SourceTable;
 import io.cdap.delta.api.assessment.ColumnDetail;
+import io.cdap.delta.api.assessment.StandardizedTableDetail;
 import io.cdap.delta.api.assessment.TableAssessor;
 import io.cdap.delta.api.assessment.TableDetail;
 import io.cdap.delta.api.assessment.TableList;
@@ -91,7 +92,7 @@ public class MockSource implements DeltaSource {
       }
 
       @Override
-      public Schema standardizeSchema(List<ColumnDetail> tableDetail) {
+      public StandardizedTableDetail standardize(TableDetail tableDetail) {
         return null;
       }
 

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockTableRegistry.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockTableRegistry.java
@@ -17,12 +17,10 @@
 package io.cdap.delta.test.mock;
 
 import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.delta.api.assessment.ColumnDetail;
+import io.cdap.delta.api.assessment.StandardizedTableDetail;
 import io.cdap.delta.api.assessment.TableDetail;
 import io.cdap.delta.api.assessment.TableList;
 import io.cdap.delta.api.assessment.TableRegistry;
-
-import java.util.List;
 
 /**
  * Mock TableRegistry that just returns pre-defined objects.
@@ -49,8 +47,9 @@ public class MockTableRegistry implements TableRegistry {
   }
 
   @Override
-  public Schema standardizeSchema(List<ColumnDetail> tableDetail) {
-    return schema;
+  public StandardizedTableDetail standardize(TableDetail tableDetail) {
+    return new StandardizedTableDetail(tableDetail.getDatabase(), tableDetail.getTable(),
+                                       tableDetail.getPrimaryKey(), schema);
   }
 
   @Override


### PR DESCRIPTION
Modified the standardize API to pass in the full table detail.
The full information is useful when generating a name for the record
schema that needs to be returned.