### PR TITLE
fix the table assessment endpoint response

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/ColumnAssessment.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/ColumnAssessment.java
@@ -25,35 +25,52 @@ import javax.annotation.Nullable;
 public class ColumnAssessment {
   private final String name;
   private final String type;
+  private final String sourceName;
   private final ColumnSupport support;
   private final ColumnSuggestion suggestion;
 
-  public ColumnAssessment(String name, String type) {
+  private ColumnAssessment(ColumnSupport support, String name, String type,
+                           @Nullable String sourceName, @Nullable ColumnSuggestion suggestion) {
     this.name = name;
     this.type = type;
-    this.support = ColumnSupport.YES;
-    this.suggestion = null;
-  }
-
-  public ColumnAssessment(String name, String type, ColumnSupport support, ColumnSuggestion suggestion) {
-    this.name = name;
-    this.type = type;
+    this.sourceName = sourceName;
     this.support = support;
     this.suggestion = suggestion;
   }
 
+  /**
+   * @return the name of the column as seen by the source. This only needs to be set for column assessments on the
+   *   target, in case the column name was normalized or transformed in some way.
+   */
+  @Nullable
+  public String getSourceName() {
+    return sourceName;
+  }
+
+  /**
+   * @return name of the column
+   */
   public String getName() {
     return name;
   }
 
+  /**
+   * @return type of the column
+   */
   public String getType() {
     return type;
   }
 
+  /**
+   * @return level of support for the column
+   */
   public ColumnSupport getSupport() {
     return support;
   }
 
+  /**
+   * @return a suggestion to improve support level for the column
+   */
   @Nullable
   public ColumnSuggestion getSuggestion() {
     return suggestion;
@@ -68,14 +85,58 @@ public class ColumnAssessment {
       return false;
     }
     ColumnAssessment that = (ColumnAssessment) o;
-    return support == that.support &&
-      Objects.equals(name, that.name) &&
+    return Objects.equals(name, that.name) &&
       Objects.equals(type, that.type) &&
+      Objects.equals(sourceName, that.sourceName) &&
+      support == that.support &&
       Objects.equals(suggestion, that.suggestion);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, type, support, suggestion);
+    return Objects.hash(name, type, sourceName, support, suggestion);
+  }
+
+  /**
+   * return a Builder to create column assessments
+   */
+  public static Builder builder(String name, String type) {
+    return new Builder(name, type);
+  }
+
+  /**
+   * Builds a ColumnAssessment
+   */
+  public static class Builder {
+    private String name;
+    private String type;
+    private String sourceName;
+    private ColumnSupport support;
+    private ColumnSuggestion suggestion;
+
+    private Builder(String name, String type) {
+      this.name = name;
+      this.type = type;
+      this.support = ColumnSupport.YES;
+    }
+
+    public Builder setSupport(ColumnSupport support) {
+      this.support = support;
+      return this;
+    }
+
+    public Builder setSuggestion(ColumnSuggestion suggestion) {
+      this.suggestion = suggestion;
+      return this;
+    }
+
+    public Builder setSourceColumn(String sourceColumnName) {
+      this.sourceName = sourceColumnName;
+      return this;
+    }
+
+    public ColumnAssessment build() {
+      return new ColumnAssessment(support, name, type, sourceName, suggestion);
+    }
   }
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/PipelineAssessment.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/PipelineAssessment.java
@@ -30,11 +30,11 @@ public class PipelineAssessment {
   private final List<Problem> connectivity;
 
   public PipelineAssessment(List<TableSummaryAssessment> tables,
-                            List<Problem> features,
-                            List<Problem> connectivity) {
+                            List<Problem> featureProblems,
+                            List<Problem> connectivityProblems) {
     this.tables = Collections.unmodifiableList(new ArrayList<>(tables));
-    this.features = Collections.unmodifiableList(new ArrayList<>(features));
-    this.connectivity = Collections.unmodifiableList(new ArrayList<>(connectivity));
+    this.features = Collections.unmodifiableList(new ArrayList<>(featureProblems));
+    this.connectivity = Collections.unmodifiableList(new ArrayList<>(connectivityProblems));
   }
 
   /**
@@ -47,14 +47,14 @@ public class PipelineAssessment {
   /**
    * @return potential problems related to features
    */
-  public List<Problem> getFeatures() {
+  public List<Problem> getFeatureProblems() {
     return features;
   }
 
   /**
    * @return potential problems related to connectivity
    */
-  public List<Problem> getConnectivity() {
+  public List<Problem> getConnectivityProblem() {
     return connectivity;
   }
 

--- a/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentHandler.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentHandler.java
@@ -26,7 +26,6 @@ import io.cdap.cdap.api.service.http.HttpServiceRequest;
 import io.cdap.cdap.api.service.http.HttpServiceResponder;
 import io.cdap.cdap.api.service.http.SystemHttpServiceContext;
 import io.cdap.delta.api.assessment.PipelineAssessment;
-import io.cdap.delta.api.assessment.TableAssessment;
 import io.cdap.delta.api.assessment.TableDetail;
 import io.cdap.delta.api.assessment.TableList;
 import io.cdap.delta.api.assessment.TableNotFoundException;
@@ -34,6 +33,7 @@ import io.cdap.delta.app.DefaultConfigurer;
 import io.cdap.delta.proto.CodedException;
 import io.cdap.delta.proto.DBTable;
 import io.cdap.delta.proto.DraftRequest;
+import io.cdap.delta.proto.TableAssessmentResponse;
 import io.cdap.delta.store.Draft;
 import io.cdap.delta.store.DraftId;
 import io.cdap.delta.store.DraftService;
@@ -187,8 +187,8 @@ public class AssessmentHandler extends AbstractSystemHttpServiceHandler {
       }
 
       PluginConfigurer pluginConfigurer = getContext().createPluginConfigurer(namespaceName);
-      TableAssessment assessment = draftService.assessTable(draftId, new DefaultConfigurer(pluginConfigurer),
-                                                            dbTable.getDatabase(), dbTable.getTable());
+      TableAssessmentResponse assessment = draftService.assessTable(draftId, new DefaultConfigurer(pluginConfigurer),
+                                                                    dbTable.getDatabase(), dbTable.getTable());
       responder.sendString(GSON.toJson(assessment));
     }));
   }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/FullColumnAssessment.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/FullColumnAssessment.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import io.cdap.delta.api.assessment.ColumnSuggestion;
+import io.cdap.delta.api.assessment.ColumnSupport;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Column assessment containing information from both the source and target. Types are system specific type names.
+ * For example, when reading from a database, the source type should be a type familiar to users of those databases.
+ * Similarly, the target type should be a type familiar to users of that target system.
+ * Column names in the source and target may also differ, either because of a user specified transformation, or because
+ * the source name had to be normalized because the target system has a different supported character set.
+ */
+public class FullColumnAssessment {
+  private final ColumnSupport support;
+  private final String sourceName;
+  private final String sourceType;
+  private final String targetName;
+  private final String targetType;
+  private final ColumnSuggestion suggestion;
+
+  public FullColumnAssessment(ColumnSupport support, @Nullable String sourceName, @Nullable String sourceType,
+                              @Nullable String targetName, @Nullable String targetType,
+                              @Nullable ColumnSuggestion suggestion) {
+    this.support = support;
+    this.sourceName = sourceName;
+    this.sourceType = sourceType;
+    this.targetName = targetName;
+    this.targetType = targetType;
+    this.suggestion = suggestion;
+  }
+
+  public ColumnSupport getSupport() {
+    return support;
+  }
+
+  @Nullable
+  public String getSourceName() {
+    return sourceName;
+  }
+
+  @Nullable
+  public String getSourceType() {
+    return sourceType;
+  }
+
+  @Nullable
+  public String getTargetName() {
+    return targetName;
+  }
+
+  @Nullable
+  public String getTargetType() {
+    return targetType;
+  }
+
+  @Nullable
+  public ColumnSuggestion getSuggestion() {
+    return suggestion;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    FullColumnAssessment that = (FullColumnAssessment) o;
+    return support == that.support &&
+      Objects.equals(sourceName, that.sourceName) &&
+      Objects.equals(sourceType, that.sourceType) &&
+      Objects.equals(targetName, that.targetName) &&
+      Objects.equals(targetType, that.targetType) &&
+      Objects.equals(suggestion, that.suggestion);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(support, sourceName, sourceType, targetName, targetType, suggestion);
+  }
+}

--- a/delta-proto/src/main/java/io/cdap/delta/proto/TableAssessmentResponse.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/TableAssessmentResponse.java
@@ -14,30 +14,31 @@
  * the License.
  */
 
-package io.cdap.delta.api.assessment;
+package io.cdap.delta.proto;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import io.cdap.delta.api.assessment.Problem;
+
 import java.util.List;
 import java.util.Objects;
 
 /**
- * A detailed assessment of issues related to a table.
+ * Full table assessment using assessments from both the source and target, and containing any problems that may
+ * occur if the table were to be replicated as-is.
  */
-public class TableAssessment {
-  private final List<ColumnAssessment> columns;
+public class TableAssessmentResponse {
+  private final List<FullColumnAssessment> columns;
   private final List<Problem> features;
 
-  public TableAssessment(List<ColumnAssessment> columns, List<Problem> featureProblems) {
-    this.columns = Collections.unmodifiableList(new ArrayList<>(columns));
-    this.features = Collections.unmodifiableList(new ArrayList<>(featureProblems));
+  public TableAssessmentResponse(List<FullColumnAssessment> columns, List<Problem> features) {
+    this.columns = columns;
+    this.features = features;
   }
 
-  public List<ColumnAssessment> getColumns() {
+  public List<FullColumnAssessment> getColumns() {
     return columns;
   }
 
-  public List<Problem> getFeatureProblems() {
+  public List<Problem> getFeatures() {
     return features;
   }
 
@@ -49,7 +50,7 @@ public class TableAssessment {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    TableAssessment that = (TableAssessment) o;
+    TableAssessmentResponse that = (TableAssessmentResponse) o;
     return Objects.equals(columns, that.columns) &&
       Objects.equals(features, that.features);
   }

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockTarget.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockTarget.java
@@ -65,7 +65,7 @@ public class MockTarget implements DeltaTarget {
 
   @Override
   public TableAssessor<StandardizedTableDetail> createTableAssessor(Configurer configurer) {
-    return tableDetail -> new TableAssessment(Collections.emptyList());
+    return tableDetail -> new TableAssessment(Collections.emptyList(), Collections.emptyList());
   }
 
   /**


### PR DESCRIPTION
Fixed the table assessment endpoint to return an object that
contains both the column name and type as seen by both the source
and target. Added a FullTableAssessment class to represent this
response. Also add a list of problems to the TableAssessment
class so that a target can record that it needs a primary key,
and other types of similar problems