### PR TITLE
CDAP-16244 add metrics for events applied

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaTargetContext.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaTargetContext.java
@@ -24,9 +24,28 @@ import java.io.IOException;
 public interface DeltaTargetContext extends DeltaRuntimeContext {
 
   /**
+   * Record that a DML operation was processed. Metrics on the number of operations processed are stored in memory
+   * and actually written out when {@link #commitOffset(Offset)} is called.
+   *
+   * @param op type of DML operation
+   */
+  void incrementCount(DMLOperation op);
+
+  /**
+   * Record that a DDL operation was processed. Metrics on the number of operations processed are stored in memory
+   * and actually written out when {@link #commitOffset(Offset)} is called.
+   *
+   * @param op type of DDL operation
+   */
+  void incrementCount(DDLOperation op);
+
+  /**
    * Commit changes up to the given offset. Once an offset is successfully committed, events up to that offset are
    * considered complete. When the program starts up, events from the last committed offset will be read. If the
    * program died before committing an offset, events may be replayed.
+   *
+   * Also writes out metrics on the number of DML and DDL operations that were applied since the last successful
+   * commit, as recorded by calls to {@link #incrementCount(DDLOperation)} and {@link #incrementCount(DMLOperation)}.
    *
    * @param offset offset to commitOffset
    */

--- a/delta-app/src/main/java/io/cdap/delta/app/DirectEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DirectEventEmitter.java
@@ -27,7 +27,6 @@ import io.cdap.delta.api.Sequenced;
 import io.cdap.delta.api.SourceTable;
 import io.cdap.delta.proto.DBTable;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/delta-app/src/main/java/io/cdap/delta/app/EventMetrics.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/EventMetrics.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app;
+
+import io.cdap.cdap.api.metrics.Metrics;
+import io.cdap.delta.api.DMLOperation;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Emits metrics about DDL and DML events.
+ */
+public class EventMetrics {
+  private final Metrics metrics;
+  private final String prefix;
+  private final Map<DMLOperation, Integer> dmlEventCounts;
+  private int ddlEventCount;
+
+  public EventMetrics(Metrics metrics, String prefix) {
+    this.metrics = metrics;
+    this.prefix = prefix;
+    this.dmlEventCounts = Arrays.stream(DMLOperation.values()).collect(Collectors.toMap(o -> o, o -> 0));
+    this.ddlEventCount = 0;
+  }
+
+  public void incrementDMLCount(DMLOperation op) {
+    dmlEventCounts.put(op, dmlEventCounts.get(op) + 1);
+  }
+
+  public void incrementDDLCount() {
+    ddlEventCount++;
+  }
+
+  public void emitMetrics() {
+    for (DMLOperation op : dmlEventCounts.keySet()) {
+      metrics.count(String.format("%s.dml.%s", prefix, op.name().toLowerCase()), dmlEventCounts.get(op));
+      dmlEventCounts.put(op, 0);
+    }
+    metrics.count(String.format("%s.ddl", prefix), ddlEventCount);
+    ddlEventCount = 0;
+  }
+}

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/FileEventConsumer.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/FileEventConsumer.java
@@ -74,12 +74,14 @@ public class FileEventConsumer implements EventConsumer {
   @Override
   public void applyDDL(Sequenced<DDLEvent> event) throws IOException {
     events.add(event.getEvent());
+    context.incrementCount(event.getEvent().getOperation());
     context.commitOffset(event.getEvent().getOffset());
   }
 
   @Override
   public void applyDML(Sequenced<DMLEvent> event) throws IOException {
     events.add(event.getEvent());
+    context.incrementCount(event.getEvent().getOperation());
     context.commitOffset(event.getEvent().getOffset());
   }
 


### PR DESCRIPTION
Added methods to the DeltaTargetContext to increment in-memory
counts for the number of DML and DDL operations replicated.
These counts are emitted as metrics after an offset is committed.
    
Target plugins must correctly increment these counters in order
for the metrics to be accurate. This cannot be done by the app
because the app does not have control over when the plugin
decides to commit the offset.