### PR TITLE
CDAP-16246 add event type filtering

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
@@ -39,12 +39,12 @@ public interface DeltaSource extends TableAssessorSupplier<TableDetail> {
    * Create an event reader used to read change events. This is called after the application is deployed, whenever
    * the program is started.
    *
-   * @param tables tables to read changes for
+   * @param definition defines what type of information the reader should read
    * @param context program context
    * @param eventEmitter emits events that need to be replicated
    * @return an event reader used to read change events
    */
-  EventReader createReader(List<SourceTable> tables, DeltaSourceContext context, EventEmitter eventEmitter);
+  EventReader createReader(EventReaderDefinition definition, DeltaSourceContext context, EventEmitter eventEmitter);
 
   /**
    * Create a table registry that is used to fetch information about tables in databases.

--- a/delta-api/src/main/java/io/cdap/delta/api/EventReaderDefinition.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/EventReaderDefinition.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Defines what types of events should a reader should emit.
+ */
+public class EventReaderDefinition {
+  private final Set<SourceTable> tables;
+  private final Set<DMLOperation> dmlBlacklist;
+  private final Set<DDLOperation> ddlBlacklist;
+
+  public EventReaderDefinition(Set<SourceTable> tables, Set<DMLOperation> dmlBlacklist,
+                               Set<DDLOperation> ddlBlacklist) {
+    this.tables = tables;
+    this.dmlBlacklist = Collections.unmodifiableSet(new HashSet<>(dmlBlacklist));
+    this.ddlBlacklist = Collections.unmodifiableSet(new HashSet<>(ddlBlacklist));
+  }
+
+  /**
+   * @return tables that should be read. If empty, it means all tables should be read.
+   */
+  public Set<SourceTable> getTables() {
+    return tables;
+  }
+
+  /**
+   * @return set of DDL operations that should always be ignored, regardless of which table they are related to.
+   */
+  public Set<DDLOperation> getDdlBlacklist() {
+    return ddlBlacklist;
+  }
+
+  /**
+   * @return set of DML operations that should always be ignored, regardless of which table they are related to.
+   */
+  public Set<DMLOperation> getDmlBlacklist() {
+    return dmlBlacklist;
+  }
+}

--- a/delta-api/src/main/java/io/cdap/delta/api/Sequenced.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/Sequenced.java
@@ -16,6 +16,8 @@
 
 package io.cdap.delta.api;
 
+import java.util.Objects;
+
 /**
  * A Change event with a sequence number.
  *
@@ -36,5 +38,23 @@ public class Sequenced<T> {
 
   public long getSequenceNumber() {
     return sequenceNumber;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Sequenced<?> sequenced = (Sequenced<?>) o;
+    return sequenceNumber == sequenced.sequenceNumber &&
+      Objects.equals(event, sequenced.event);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(event, sequenceNumber);
   }
 }

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.plugin.PluginProperties;
 import io.cdap.delta.api.Configurer;
 import io.cdap.delta.api.DeltaSource;
 import io.cdap.delta.api.DeltaTarget;
+import io.cdap.delta.api.EventReaderDefinition;
 import io.cdap.delta.app.service.AssessmentService;
 import io.cdap.delta.proto.DeltaConfig;
 import io.cdap.delta.proto.Stage;
@@ -50,8 +51,11 @@ public class DeltaApp extends AbstractApplication<DeltaConfig> {
     DeltaTarget target = registerPlugin(targetConf);
     target.configure(configurer);
 
+    EventReaderDefinition readerDefinition = new EventReaderDefinition(conf.getTables(),
+                                                                       conf.getDmlBlacklist(),
+                                                                       conf.getDdlBlacklist());
     addWorker(new DeltaWorker(sourceConf.getName(), targetConf.getName(), conf.getOffsetBasePath(),
-                              conf.getTables()));
+                              readerDefinition));
 
     String description = conf.getDescription();
     if (description == null) {

--- a/delta-app/src/main/java/io/cdap/delta/app/DirectEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DirectEventEmitter.java
@@ -17,43 +17,79 @@
 package io.cdap.delta.app;
 
 import io.cdap.delta.api.DDLEvent;
+import io.cdap.delta.api.DDLOperation;
 import io.cdap.delta.api.DMLEvent;
+import io.cdap.delta.api.DMLOperation;
 import io.cdap.delta.api.EventConsumer;
 import io.cdap.delta.api.EventEmitter;
+import io.cdap.delta.api.EventReaderDefinition;
 import io.cdap.delta.api.Sequenced;
+import io.cdap.delta.api.SourceTable;
+import io.cdap.delta.proto.DBTable;
 
 import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * In memory event emitter that simply passes the event directly to the delta target.
+ * Also filters out events that should be ignored.
  */
 public class DirectEventEmitter implements EventEmitter {
   private final EventConsumer consumer;
   private final DeltaContext context;
+  private final Set<DMLOperation> dmlBlacklist;
+  private final Set<DDLOperation> ddlBlacklist;
+  private final Map<DBTable, SourceTable> tableDefinitions;
   private long sequenceNumber;
 
-  public DirectEventEmitter(EventConsumer consumer, DeltaContext context, long sequenceNumber) {
+  public DirectEventEmitter(EventConsumer consumer, DeltaContext context, long sequenceNumber,
+                            EventReaderDefinition readerDefinition) {
     this.consumer = consumer;
     this.context = context;
     this.sequenceNumber = sequenceNumber;
+    this.dmlBlacklist = readerDefinition.getDmlBlacklist();
+    this.ddlBlacklist = readerDefinition.getDdlBlacklist();
+    this.tableDefinitions = readerDefinition.getTables().stream()
+      .collect(Collectors.toMap(t -> new DBTable(t.getDatabase(), t.getTable()), t -> t));
   }
 
   @Override
   public void emit(DDLEvent event) {
-    consumer.applyDDL(new Sequenced<>(event, sequenceNumber));
-    try {
-      context.commitOffset(event.getOffset());
-    } catch (IOException e) {
-      // TODO: handle the error, retry
-      throw new RuntimeException(e);
-    } finally {
-      sequenceNumber++;
+    if (shouldIgnore(event)) {
+      return;
     }
+
+    consumer.applyDDL(new Sequenced<>(event, sequenceNumber));
+    sequenceNumber++;
   }
 
   @Override
   public void emit(DMLEvent event) {
+    if (shouldIgnore(event)) {
+      return;
+    }
+
     consumer.applyDML(new Sequenced<>(event, sequenceNumber));
     sequenceNumber++;
+  }
+
+  private boolean shouldIgnore(DDLEvent event) {
+    if (ddlBlacklist.contains(event.getOperation())) {
+      return true;
+    }
+
+    SourceTable sourceTable = tableDefinitions.get(new DBTable(event.getDatabase(), event.getTable()));
+    return sourceTable != null && sourceTable.getDdlBlacklist().contains(event.getOperation());
+  }
+
+  private boolean shouldIgnore(DMLEvent event) {
+    if (dmlBlacklist.contains(event.getOperation())) {
+      return true;
+    }
+
+    SourceTable sourceTable = tableDefinitions.get(new DBTable(event.getDatabase(), event.getTable()));
+    return sourceTable != null && sourceTable.getDmlBlacklist().contains(event.getOperation());
   }
 }

--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -239,11 +239,11 @@ public class DraftService {
     List<TableSummaryAssessment> tableAssessments = new ArrayList<>();
 
     // if no source tables are given, this means all tables should be read
-    List<SourceTable> tablesToAssess = deltaConfig.getTables();
+    Set<SourceTable> tablesToAssess = deltaConfig.getTables();
     if (tablesToAssess.isEmpty()) {
       tablesToAssess = tableRegistry.listTables().getTables().stream()
         .map(t -> new SourceTable(t.getDatabase(), t.getTable()))
-        .collect(Collectors.toList());
+        .collect(Collectors.toSet());
     }
 
     // go through all tables that the pipeline should read, fetching detail about each of the tables

--- a/delta-app/src/test/java/io/cdap/delta/app/DirectEventEmitterTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/DirectEventEmitterTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app;
+
+import io.cdap.cdap.api.data.format.StructuredRecord;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.delta.api.DDLEvent;
+import io.cdap.delta.api.DDLOperation;
+import io.cdap.delta.api.DMLEvent;
+import io.cdap.delta.api.DMLOperation;
+import io.cdap.delta.api.EventReaderDefinition;
+import io.cdap.delta.api.Offset;
+import io.cdap.delta.api.Sequenced;
+import io.cdap.delta.api.SourceTable;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * Tests for {@link DirectEventEmitter}.
+ */
+public class DirectEventEmitterTest {
+  private static final Schema SCHEMA = Schema.recordOf("taybull", Schema.Field.of("id", Schema.of(Schema.Type.INT)));
+  private static final DDLEvent DDL = DDLEvent.builder()
+    .setOffset(new Offset(Collections.singletonMap("order", new byte[] { 0 })))
+    .setOperation(DDLOperation.CREATE_TABLE)
+    .setDatabase("deebee")
+    .setTable("taybull")
+    .setPrimaryKey(Collections.singletonList("id"))
+    .setSchema(SCHEMA)
+    .build();
+  private static final DMLEvent DML = DMLEvent.builder()
+    .setOffset(new Offset(Collections.singletonMap("order", new byte[] { 1 })))
+    .setOperation(DMLOperation.INSERT)
+    .setDatabase("deebee")
+    .setTable("taybull")
+    .setIngestTimestamp(1000L)
+    .setRow(StructuredRecord.builder(SCHEMA).set("id", 0).build())
+    .build();
+
+  @Test
+  public void testEmit() {
+    TrackingEventConsumer trackingEventConsumer = new TrackingEventConsumer();
+    EventReaderDefinition readerDefinition = new EventReaderDefinition(Collections.emptySet(), Collections.emptySet(),
+                                                                       Collections.emptySet());
+    DirectEventEmitter emitter = new DirectEventEmitter(trackingEventConsumer, null, 0L, readerDefinition);
+    emitter.emit(DDL);
+    emitter.emit(DML);
+
+    Assert.assertEquals(Collections.singletonList(new Sequenced<>(DDL, 0L)), trackingEventConsumer.getDdlEvents());
+    Assert.assertEquals(Collections.singletonList(new Sequenced<>(DML, 1L)), trackingEventConsumer.getDmlEvents());
+  }
+
+  @Test
+  public void testFiltering() {
+    TrackingEventConsumer trackingEventConsumer = new TrackingEventConsumer();
+    Set<SourceTable> tables = Collections.singleton(
+      new SourceTable("deebee", "taybull", Collections.emptySet(),
+                      Collections.singleton(DMLOperation.INSERT),
+                      Collections.singleton(DDLOperation.CREATE_TABLE)));
+    EventReaderDefinition readerDefinition = new EventReaderDefinition(tables, Collections.emptySet(),
+                                                                       Collections.emptySet());
+    DirectEventEmitter emitter = new DirectEventEmitter(trackingEventConsumer, null, 0L, readerDefinition);
+    emitter.emit(DDL);
+    emitter.emit(DML);
+
+    Assert.assertTrue(trackingEventConsumer.getDdlEvents().isEmpty());
+    Assert.assertTrue(trackingEventConsumer.getDmlEvents().isEmpty());
+  }
+
+}

--- a/delta-app/src/test/java/io/cdap/delta/app/TrackingEventConsumer.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/TrackingEventConsumer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app;
+
+import io.cdap.delta.api.DDLEvent;
+import io.cdap.delta.api.DMLEvent;
+import io.cdap.delta.api.EventConsumer;
+import io.cdap.delta.api.Sequenced;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Keeps track of the events it got, in the order it got them.
+ */
+public class TrackingEventConsumer implements EventConsumer {
+  private final List<Sequenced<DMLEvent>> dmlEvents = new ArrayList<>();
+  private final List<Sequenced<DDLEvent>> ddlEvents = new ArrayList<>();
+
+  @Override
+  public void start() {
+    // no-op
+  }
+
+  @Override
+  public void stop() {
+    // no-op
+  }
+
+  @Override
+  public void applyDDL(Sequenced<DDLEvent> event) {
+    ddlEvents.add(event);
+  }
+
+  @Override
+  public void applyDML(Sequenced<DMLEvent> event) {
+    dmlEvents.add(event);
+  }
+
+  public List<Sequenced<DMLEvent>> getDmlEvents() {
+    return dmlEvents;
+  }
+
+  public List<Sequenced<DDLEvent>> getDdlEvents() {
+    return ddlEvents;
+  }
+}

--- a/delta-app/src/test/java/io/cdap/delta/store/DraftServiceTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/DraftServiceTest.java
@@ -56,6 +56,7 @@ import java.sql.JDBCType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -169,8 +170,8 @@ public class DraftServiceTest extends SystemAppTestBase {
     DraftService service = new DraftService(getTransactionRunner(), NoOpPropertyEvaluator.INSTANCE);
     DraftId draftId = new DraftId(new Namespace("ns", 0L), "testAssessPipeline");
     // configure the pipeline to read 2 out of the 3 columns from the table
-    SourceTable sourceTable = new SourceTable("deebee", "taybull",
-                                              Arrays.asList(new SourceColumn("id"), new SourceColumn("name")));
+    SourceTable sourceTable = new SourceTable(
+      "deebee", "taybull", new HashSet<>(Arrays.asList(new SourceColumn("id"), new SourceColumn("name"))));
     DeltaConfig config = DeltaConfig.builder()
       .setSource(new Stage("src", new Plugin("mock", DeltaSource.PLUGIN_TYPE, Collections.emptyMap(), Artifact.EMPTY)))
       .setTarget(new Stage("t", new Plugin("oracle", DeltaTarget.PLUGIN_TYPE, Collections.emptyMap(), Artifact.EMPTY)))

--- a/delta-app/src/test/java/io/cdap/delta/store/MockSource.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/MockSource.java
@@ -21,12 +21,10 @@ import io.cdap.delta.api.DeltaSource;
 import io.cdap.delta.api.DeltaSourceContext;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.EventReader;
-import io.cdap.delta.api.SourceTable;
+import io.cdap.delta.api.EventReaderDefinition;
 import io.cdap.delta.api.assessment.TableAssessor;
 import io.cdap.delta.api.assessment.TableDetail;
 import io.cdap.delta.api.assessment.TableRegistry;
-
-import java.util.List;
 
 
 /**
@@ -47,7 +45,7 @@ public class MockSource implements DeltaSource {
   }
 
   @Override
-  public EventReader createReader(List<SourceTable> tables, DeltaSourceContext context, EventEmitter eventEmitter) {
+  public EventReader createReader(EventReaderDefinition definition, DeltaSourceContext context, EventEmitter emitter) {
     return null;
   }
 

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockSource.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockSource.java
@@ -32,6 +32,7 @@ import io.cdap.delta.api.DeltaSource;
 import io.cdap.delta.api.DeltaSourceContext;
 import io.cdap.delta.api.EventEmitter;
 import io.cdap.delta.api.EventReader;
+import io.cdap.delta.api.EventReaderDefinition;
 import io.cdap.delta.api.SourceTable;
 import io.cdap.delta.api.assessment.ColumnDetail;
 import io.cdap.delta.api.assessment.StandardizedTableDetail;
@@ -71,9 +72,9 @@ public class MockSource implements DeltaSource {
   }
 
   @Override
-  public EventReader createReader(List<SourceTable> tables, DeltaSourceContext context, EventEmitter eventEmitter) {
+  public EventReader createReader(EventReaderDefinition definition, DeltaSourceContext context, EventEmitter emitter) {
     return new MockEventReader(GSON.fromJson(conf.events, new TypeToken<List<? extends ChangeEvent>>() { }.getType()),
-                               eventEmitter, conf.maxEvents);
+                               emitter, conf.maxEvents);
   }
 
   @Override


### PR DESCRIPTION
Enhanced the config to allow the user to specify a blacklist for
DML and DDL event types. A blacklist can be set at the pipeline
level for all tables, or for a specific table.

Refactored the source API to take a new EventReaderDefinition
class that contains information about what to read. This is more
extensible, as it allows us to add more constraints without breaking
backwards compatibility in the API.