### PR TITLE
fix unit test

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
@@ -37,14 +37,16 @@ public interface DeltaSource extends TableAssessorSupplier<TableDetail> {
 
   /**
    * Create an event reader used to read change events. This is called after the application is deployed, whenever
-   * the program is started.
+   * the program is started. If an exception is thrown, the pipeline run will fail.
    *
    * @param definition defines what type of information the reader should read
    * @param context program context
    * @param eventEmitter emits events that need to be replicated
    * @return an event reader used to read change events
+   * @throws Exception if there was an error creating the event reader
    */
-  EventReader createReader(EventReaderDefinition definition, DeltaSourceContext context, EventEmitter eventEmitter);
+  EventReader createReader(EventReaderDefinition definition, DeltaSourceContext context,
+                           EventEmitter eventEmitter) throws Exception;
 
   /**
    * Create a table registry that is used to fetch information about tables in databases.
@@ -52,6 +54,7 @@ public interface DeltaSource extends TableAssessorSupplier<TableDetail> {
    *
    * @param configurer configurer used to instantiate plugins
    * @return table registry used to fetch information about tables in databases.
+   * @throws Exception if there was an error creating the table registry
    */
-  TableRegistry createTableRegistry(Configurer configurer);
+  TableRegistry createTableRegistry(Configurer configurer) throws Exception;
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/EventConsumer.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/EventConsumer.java
@@ -44,8 +44,9 @@ public interface EventConsumer {
    * successfully.
    *
    * @param event ddl event to apply
+   * @throws Exception if there was an error applying the change
    */
-  void applyDDL(Sequenced<DDLEvent> event);
+  void applyDDL(Sequenced<DDLEvent> event) throws Exception;
 
   /**
    * Apply a DML event. This method must be idempotent. For example, if there is an insert and the row already exists,
@@ -57,7 +58,8 @@ public interface EventConsumer {
    * In failure scenarios the batch will be applied at least once.
    *
    * @param event DML event to apply
+   * @throws Exception if there was an error applying the change
    */
-  void applyDML(Sequenced<DMLEvent> event);
+  void applyDML(Sequenced<DMLEvent> event) throws Exception;
 
 }

--- a/delta-app/src/main/java/io/cdap/delta/app/DirectEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DirectEventEmitter.java
@@ -61,7 +61,12 @@ public class DirectEventEmitter implements EventEmitter {
       return;
     }
 
-    consumer.applyDDL(new Sequenced<>(event, sequenceNumber));
+    try {
+      consumer.applyDDL(new Sequenced<>(event, sequenceNumber));
+    } catch (Exception e) {
+      // TODO: (CDAP-16251) retry
+      throw new RuntimeException(e);
+    }
     sequenceNumber++;
   }
 
@@ -71,7 +76,12 @@ public class DirectEventEmitter implements EventEmitter {
       return;
     }
 
-    consumer.applyDML(new Sequenced<>(event, sequenceNumber));
+    try {
+      consumer.applyDML(new Sequenced<>(event, sequenceNumber));
+    } catch (Exception e) {
+      // TODO: (CDAP-16251) retry
+      throw new RuntimeException(e);
+    }
     sequenceNumber++;
   }
 

--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -143,8 +143,9 @@ public class DraftService {
    * @throws DraftNotFoundException if the draft does not exist
    * @throws InvalidDraftException if the table list cannot be fetched because the draft is invalid
    * @throws IOException if the was an IO error fetching the table list
+   * @throws Exception if there was an error creating the table registry
    */
-  public TableList listDraftTables(DraftId draftId, Configurer configurer) throws IOException {
+  public TableList listDraftTables(DraftId draftId, Configurer configurer) throws Exception {
     Draft draft = getDraft(draftId);
     try (TableRegistry tableRegistry = createTableRegistry(draftId, draft, configurer)) {
       return tableRegistry.listTables();
@@ -167,9 +168,10 @@ public class DraftService {
    * @throws InvalidDraftException if the table list cannot be fetched because the draft is invalid
    * @throws TableNotFoundException if the table does not exist
    * @throws IOException if the was an IO error fetching the table detail
+   * @throws Exception if there was an error creating the table registry
    */
   public TableDetail describeDraftTable(DraftId draftId, Configurer configurer, String database, String table)
-    throws IOException, TableNotFoundException {
+    throws Exception {
     Draft draft = getDraft(draftId);
     try (TableRegistry tableRegistry = createTableRegistry(draftId, draft, configurer)) {
       return tableRegistry.describeTable(database, table);
@@ -192,9 +194,10 @@ public class DraftService {
    * @throws InvalidDraftException if the table list cannot be fetched because the draft is invalid
    * @throws TableNotFoundException if the table does not exist
    * @throws IOException if the table detail could not be read
+   * @throws Exception if there was an error creating the table registry
    */
   public TableAssessmentResponse assessTable(DraftId draftId, Configurer configurer, String db, String table)
-    throws IOException, TableNotFoundException {
+    throws Exception {
     Draft draft = getDraft(draftId);
     DeltaConfig deltaConfig = draft.getConfig();
     deltaConfig = evaluateMacros(draftId, deltaConfig);
@@ -222,8 +225,9 @@ public class DraftService {
    * @throws DraftNotFoundException if the draft does not exist
    * @throws InvalidDraftException if the table list cannot be fetched because the draft is invalid
    * @throws IOException if there was an IO error getting the list of source tables
+   * @throws Exception if there was an error creating the table registry
    */
-  public PipelineAssessment assessPipeline(DraftId draftId, Configurer configurer) throws IOException {
+  public PipelineAssessment assessPipeline(DraftId draftId, Configurer configurer) throws Exception {
     Draft draft = getDraft(draftId);
     DeltaConfig deltaConfig = draft.getConfig();
     deltaConfig.validatePipeline();
@@ -351,7 +355,7 @@ public class DraftService {
                                     suggestion);
   }
 
-  private TableRegistry createTableRegistry(DraftId id, Draft draft, Configurer configurer) {
+  private TableRegistry createTableRegistry(DraftId id, Draft draft, Configurer configurer) throws Exception {
     DeltaConfig deltaConfig = draft.getConfig();
     deltaConfig = evaluateMacros(id, deltaConfig);
     Stage stage = deltaConfig.getSource();

--- a/delta-app/src/test/java/io/cdap/delta/store/DraftServiceTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/DraftServiceTest.java
@@ -51,7 +51,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.sql.JDBCType;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -112,7 +111,7 @@ public class DraftServiceTest extends SystemAppTestBase {
   }
 
   @Test(expected = DraftNotFoundException.class)
-  public void testListTablesFromNonexistantDraft() throws IOException {
+  public void testListTablesFromNonexistantDraft() throws Exception {
     DraftService service = new DraftService(getTransactionRunner(), NoOpPropertyEvaluator.INSTANCE);
     service.listDraftTables(new DraftId(new Namespace("ns", 0L), "testListTablesFromNonexistantDraft"),
                             new MockConfigurer(null, null));

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/FileEventConsumer.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/FileEventConsumer.java
@@ -25,6 +25,7 @@ import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import io.cdap.delta.api.ChangeEvent;
 import io.cdap.delta.api.DDLEvent;
 import io.cdap.delta.api.DMLEvent;
+import io.cdap.delta.api.DeltaTargetContext;
 import io.cdap.delta.api.EventConsumer;
 import io.cdap.delta.api.Sequenced;
 
@@ -48,10 +49,12 @@ public class FileEventConsumer implements EventConsumer {
     .create();
   private final File file;
   private final List<ChangeEvent> events;
+  private final DeltaTargetContext context;
 
-  public FileEventConsumer(File file) {
+  public FileEventConsumer(File file, DeltaTargetContext context) {
     this.file = file;
     this.events = new ArrayList<>();
+    this.context = context;
   }
 
   @Override
@@ -69,13 +72,15 @@ public class FileEventConsumer implements EventConsumer {
   }
 
   @Override
-  public void applyDDL(Sequenced<DDLEvent> event) {
+  public void applyDDL(Sequenced<DDLEvent> event) throws IOException {
     events.add(event.getEvent());
+    context.commitOffset(event.getEvent().getOffset());
   }
 
   @Override
-  public void applyDML(Sequenced<DMLEvent> event) {
+  public void applyDML(Sequenced<DMLEvent> event) throws IOException {
     events.add(event.getEvent());
+    context.commitOffset(event.getEvent().getOffset());
   }
 
   /**

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockTarget.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockTarget.java
@@ -60,7 +60,7 @@ public class MockTarget implements DeltaTarget {
     if (outputFile.exists()) {
       outputFile.delete();
     }
-    return new FileEventConsumer(outputFile);
+    return new FileEventConsumer(outputFile, context);
   }
 
   @Override


### PR DESCRIPTION
Also allow APIs to throw exception, since we found the plugin implementations are often wrapping their checked exceptions in runtime exceptions.