### PR TITLE
add schema field to table detail and source table

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/SourceTable.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/SourceTable.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Object representing what data from a table should be read by the source.
@@ -28,6 +29,10 @@ import java.util.Set;
 public class SourceTable {
   private final String database;
   private final String table;
+  // this schema is required for some db to uniquely identify the table, if this is not provided, it will not
+  // be able to fetch the records
+  // TODO: CDAP-16261 have a better way to identify the table
+  private final String schema;
   private final Set<SourceColumn> columns;
   private final Set<DMLOperation> dmlBlacklist;
   private final Set<DDLOperation> ddlBlacklist;
@@ -37,13 +42,15 @@ public class SourceTable {
   }
 
   public SourceTable(String database, String table, Set<SourceColumn> columns) {
-    this(database, table, columns, Collections.emptySet(), Collections.emptySet());
+    this(database, table, null, columns, Collections.emptySet(), Collections.emptySet());
   }
 
-  public SourceTable(String database, String table, Set<SourceColumn> columns, Set<DMLOperation> dmlBlacklist,
+  public SourceTable(String database, String table, @Nullable String schema,
+                     Set<SourceColumn> columns, Set<DMLOperation> dmlBlacklist,
                      Set<DDLOperation> ddlBlacklist) {
     this.database = database;
     this.table = table;
+    this.schema = schema;
     this.columns = columns;
     this.dmlBlacklist = new HashSet<>(dmlBlacklist);
     this.ddlBlacklist = new HashSet<>(ddlBlacklist);
@@ -72,6 +79,11 @@ public class SourceTable {
     return dmlBlacklist == null ? Collections.emptySet() : Collections.unmodifiableSet(dmlBlacklist);
   }
 
+  @Nullable
+  public String getSchema() {
+    return schema;
+  }
+
   /**
    * @return set of DDL operations that should be ignored
    */
@@ -92,11 +104,12 @@ public class SourceTable {
       Objects.equals(table, that.table) &&
       Objects.equals(columns, that.columns) &&
       Objects.equals(dmlBlacklist, that.dmlBlacklist) &&
-      Objects.equals(ddlBlacklist, that.ddlBlacklist);
+      Objects.equals(ddlBlacklist, that.ddlBlacklist) &&
+      Objects.equals(schema, that.schema);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(database, table, columns, dmlBlacklist, ddlBlacklist);
+    return Objects.hash(database, table, columns, dmlBlacklist, ddlBlacklist, schema);
   }
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableDetail.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableDetail.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 
 /**
  * Detailed information about a table.
@@ -27,11 +28,21 @@ import java.util.Objects;
 public class TableDetail extends TableSummary {
   private final List<String> primaryKey;
   private final List<ColumnDetail> columns;
+  // this schema is required for some db to uniquely identify the table, if this is not provided, it will not
+  // be able to fetch the records
+  private final String schema;
 
-  public TableDetail(String database, String table, List<String> primaryKey, List<ColumnDetail> columns) {
+  public TableDetail(String database, String table, @Nullable String schema,
+                     List<String> primaryKey, List<ColumnDetail> columns) {
     super(database, table, columns.size());
+    this.schema = schema;
     this.primaryKey = Collections.unmodifiableList(new ArrayList<>(primaryKey));
     this.columns = Collections.unmodifiableList(new ArrayList<>(columns));
+  }
+
+  @Nullable
+  public String getSchema() {
+    return schema;
   }
 
   public List<String> getPrimaryKey() {
@@ -55,11 +66,12 @@ public class TableDetail extends TableSummary {
     }
     TableDetail that = (TableDetail) o;
     return Objects.equals(primaryKey, that.primaryKey) &&
-      Objects.equals(columns, that.columns);
+      Objects.equals(columns, that.columns) &&
+      Objects.equals(schema, that.schema);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), primaryKey, columns);
+    return Objects.hash(super.hashCode(), primaryKey, columns, schema);
   }
 }

--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -292,7 +292,7 @@ public class DraftService {
       // if there are no columns specified, it means all columns should be read
       .filter(columnWhitelist.isEmpty() ? col -> true : col -> columnWhitelist.contains(col.getName()))
       .collect(Collectors.toList());
-    TableDetail filteredDetail = new TableDetail(db, table, detail.getPrimaryKey(), selectedColumns);
+    TableDetail filteredDetail = new TableDetail(db, table, null, detail.getPrimaryKey(), selectedColumns);
     TableAssessment srcAssessment = sourceTableAssessor.assess(filteredDetail);
 
     StandardizedTableDetail standardizedDetail = tableRegistry.standardize(filteredDetail);

--- a/delta-app/src/test/java/io/cdap/delta/app/DirectEventEmitterTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/DirectEventEmitterTest.java
@@ -71,7 +71,7 @@ public class DirectEventEmitterTest {
   public void testFiltering() {
     TrackingEventConsumer trackingEventConsumer = new TrackingEventConsumer();
     Set<SourceTable> tables = Collections.singleton(
-      new SourceTable("deebee", "taybull", Collections.emptySet(),
+      new SourceTable("deebee", "taybull", null, Collections.emptySet(),
                       Collections.singleton(DMLOperation.INSERT),
                       Collections.singleton(DDLOperation.CREATE_TABLE)));
     EventReaderDefinition readerDefinition = new EventReaderDefinition(tables, Collections.emptySet(),

--- a/delta-app/src/test/java/io/cdap/delta/store/DraftServiceTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/DraftServiceTest.java
@@ -101,7 +101,7 @@ public class DraftServiceTest extends SystemAppTestBase {
     columns.add(new ColumnDetail("id", JDBCType.INTEGER, false));
     columns.add(new ColumnDetail("name", JDBCType.VARCHAR, false));
     columns.add(new ColumnDetail("age", JDBCType.INTEGER, true));
-    TableDetail expectedDetail = new TableDetail("deebee", "taybull", Collections.singletonList("id"), columns);
+    TableDetail expectedDetail = new TableDetail("deebee", "taybull", null, Collections.singletonList("id"), columns);
 
     MockTableRegistry mockTableRegistry = new MockTableRegistry(expectedList, expectedDetail, null);
     DeltaSource mockSource = new MockSource(mockTableRegistry, null);
@@ -137,7 +137,7 @@ public class DraftServiceTest extends SystemAppTestBase {
       Schema.Field.of("id", Schema.of(Schema.Type.INT)),
       Schema.Field.of("name", Schema.of(Schema.Type.STRING)),
       Schema.Field.of("age", Schema.nullableOf(Schema.of(Schema.Type.INT))));
-    TableDetail expectedDetail = new TableDetail("deebee", "taybull", Collections.singletonList("id"), columns);
+    TableDetail expectedDetail = new TableDetail("deebee", "taybull", null, Collections.singletonList("id"), columns);
 
     List<ColumnAssessment> columnAssessments = new ArrayList<>();
     columnAssessments.add(ColumnAssessment.builder("id", "int").setSourceColumn("id").build());
@@ -187,7 +187,7 @@ public class DraftServiceTest extends SystemAppTestBase {
       "taybull",
       Schema.Field.of("id", Schema.of(Schema.Type.INT)),
       Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
-    TableDetail expectedDetail = new TableDetail("deebee", "taybull", Collections.singletonList("id"), columns);
+    TableDetail expectedDetail = new TableDetail("deebee", "taybull", null, Collections.singletonList("id"), columns);
 
     List<ColumnAssessment> columnAssessments = new ArrayList<>();
     columnAssessments.add(ColumnAssessment.builder("id", "int").setSourceColumn("id").build());
@@ -224,7 +224,7 @@ public class DraftServiceTest extends SystemAppTestBase {
       "taybull",
       Schema.Field.of("id", Schema.of(Schema.Type.INT)),
       Schema.Field.of("name", Schema.of(Schema.Type.STRING)));
-    TableDetail expectedDetail = new TableDetail("deebee", "taybull", Collections.singletonList("id"), columns);
+    TableDetail expectedDetail = new TableDetail("deebee", "taybull", null, Collections.singletonList("id"), columns);
 
     List<ColumnAssessment> columnAssessments = new ArrayList<>();
     columnAssessments.add(ColumnAssessment.builder("id", "int").setSourceColumn("id").build());


### PR DESCRIPTION
Add a schema field to table detail and source table. This is required since for SQLServer, the full table name has to be passed in to Debizium as [schemaName].[tableName] to be able to read records from it. I think it is similar case for Oracle. We cannot simply return the full name in `TableSummary` because when jdbc tries to fetch the metadata, using full table name will not return anything. So adding this to SourceTable so that we can get it back to construct the full table name.