### PR TITLE
CDAP-16245 add table state apis

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/ChangeEvent.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/ChangeEvent.java
@@ -23,13 +23,19 @@ import java.util.Objects;
  */
 public abstract class ChangeEvent {
   private final Offset offset;
+  private final boolean isSnapshot;
 
-  protected ChangeEvent(Offset offset) {
+  protected ChangeEvent(Offset offset, boolean isSnapshot) {
     this.offset = offset;
+    this.isSnapshot = isSnapshot;
   }
 
   public Offset getOffset() {
     return offset;
+  }
+
+  public boolean isSnapshot() {
+    return isSnapshot;
   }
 
   @Override
@@ -41,11 +47,32 @@ public abstract class ChangeEvent {
       return false;
     }
     ChangeEvent that = (ChangeEvent) o;
-    return Objects.equals(offset, that.offset);
+    return isSnapshot == that.isSnapshot &&
+      Objects.equals(offset, that.offset);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(offset);
+    return Objects.hash(offset, isSnapshot);
+  }
+
+  /**
+   * Builds a ChangeEvent
+   *
+   * @param <T> type of builder
+   */
+  public static class Builder<T extends Builder> {
+    protected Offset offset;
+    protected boolean isSnapshot;
+
+    public T setOffset(Offset offset) {
+      this.offset = offset;
+      return (T) this;
+    }
+
+    public T setSnapshot(boolean isSnapshot) {
+      this.isSnapshot = isSnapshot;
+      return (T) this;
+    }
   }
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/DDLEvent.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DDLEvent.java
@@ -36,8 +36,8 @@ public class DDLEvent extends ChangeEvent {
   private final List<String> primaryKey;
 
   private DDLEvent(Offset offset, DDLOperation operation, @Nullable Schema schema, String database,
-                   @Nullable String prevTable, @Nullable String table, List<String> primaryKey) {
-    super(offset);
+                   @Nullable String prevTable, @Nullable String table, List<String> primaryKey, boolean isSnapshot) {
+    super(offset, isSnapshot);
     this.operation = operation;
     this.schema = schema;
     this.database = database;
@@ -104,7 +104,7 @@ public class DDLEvent extends ChangeEvent {
   /**
    * Builder for a DDL event.
    */
-  public static class Builder {
+  public static class Builder extends ChangeEvent.Builder {
     private Offset offset;
     private DDLOperation operation;
     private Schema schema;
@@ -149,7 +149,7 @@ public class DDLEvent extends ChangeEvent {
     }
 
     public DDLEvent build() {
-      return new DDLEvent(offset, operation, schema, database, prevTable, table, primaryKey);
+      return new DDLEvent(offset, operation, schema, database, prevTable, table, primaryKey, isSnapshot);
     }
   }
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/DMLEvent.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DMLEvent.java
@@ -32,9 +32,9 @@ public class DMLEvent extends ChangeEvent {
   private final String transactionId;
   private final long ingestTimestampMillis;
 
-  public DMLEvent(Offset offset, DMLOperation operation, String database, String table, StructuredRecord row,
-                  @Nullable String transactionId, long ingestTimestampMillis) {
-    super(offset);
+  private DMLEvent(Offset offset, DMLOperation operation, String database, String table, StructuredRecord row,
+                   @Nullable String transactionId, long ingestTimestampMillis, boolean isSnapshot) {
+    super(offset, isSnapshot);
     this.operation = operation;
     this.database = database;
     this.table = table;
@@ -110,19 +110,13 @@ public class DMLEvent extends ChangeEvent {
   /**
    * Builder for a DML event.
    */
-  public static class Builder {
+  public static class Builder extends ChangeEvent.Builder<Builder> {
     private DMLOperation operation;
     private String database;
     private String table;
     private StructuredRecord row;
     private String transactionId;
     private long ingestTimestampMillis;
-    private Offset offset;
-
-    public Builder setOffset(Offset offset) {
-      this.offset = offset;
-      return this;
-    }
 
     public Builder setOperation(DMLOperation operation) {
       this.operation = operation;
@@ -155,7 +149,7 @@ public class DMLEvent extends ChangeEvent {
     }
 
     public DMLEvent build() {
-      return new DMLEvent(offset, operation, database, table, row, transactionId, ingestTimestampMillis);
+      return new DMLEvent(offset, operation, database, table, row, transactionId, ingestTimestampMillis, isSnapshot);
     }
   }
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaSourceContext.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaSourceContext.java
@@ -21,4 +21,15 @@ package io.cdap.delta.api;
  */
 public interface DeltaSourceContext extends DeltaRuntimeContext {
 
+  /**
+   * Record that there are currently errors reading change events.
+   *
+   * @param error information about the error
+   */
+  void setError(ReplicationError error);
+
+  /**
+   * Record that there are no errors reading change events.
+   */
+  void setOK();
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/ReplicationError.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/ReplicationError.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/**
+ * A replication error, generally caused by a java exception. This is basically a serializable exception.
+ */
+public class ReplicationError {
+  private final String message;
+  private final StackTraceElement[] stackTrace;
+
+  public ReplicationError(Exception e) {
+    this(e.getMessage(), e.getStackTrace());
+  }
+
+  public ReplicationError(String message, StackTraceElement[] stackTrace) {
+    this.message = message;
+    this.stackTrace = stackTrace;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ReplicationError that = (ReplicationError) o;
+    return Objects.equals(message, that.message) &&
+      Arrays.equals(stackTrace, that.stackTrace);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(message);
+    result = 31 * result + Arrays.hashCode(stackTrace);
+    return result;
+  }
+}

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
@@ -36,7 +36,7 @@ public class DeltaApp extends AbstractApplication<DeltaConfig> {
     DeltaConfig conf = getConfig();
 
     if (conf.isService()) {
-      addService(new AssessmentService());
+      addService(new AssessmentService(conf.getOffsetBasePath()));
       setDescription("Delta Pipeline System Service");
       return;
     }

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaPipelineId.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaPipelineId.java
@@ -17,14 +17,15 @@
 package io.cdap.delta.app;
 
 /**
- * Uniquely identifies a delta pipeline
+ * Uniquely identifies a delta pipeline.
+ * The generation is used to distinguish between pipeline X that was created, then deleted, then created again.
  */
 public class DeltaPipelineId {
   private final String namespace;
   private final String app;
-  private final String generation;
+  private final long generation;
 
-  public DeltaPipelineId(String namespace, String app, String generation) {
+  public DeltaPipelineId(String namespace, String app, long generation) {
     this.namespace = namespace;
     this.app = app;
     this.generation = generation;
@@ -38,7 +39,7 @@ public class DeltaPipelineId {
     return app;
   }
 
-  public String getGeneration() {
+  public long getGeneration() {
     return generation;
   }
 }

--- a/delta-app/src/main/java/io/cdap/delta/app/DirectEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DirectEventEmitter.java
@@ -60,13 +60,13 @@ public class DirectEventEmitter implements EventEmitter {
       return;
     }
 
+    sequenceNumber++;
     try {
       consumer.applyDDL(new Sequenced<>(event, sequenceNumber));
     } catch (Exception e) {
       // TODO: (CDAP-16251) retry
       throw new RuntimeException(e);
     }
-    sequenceNumber++;
   }
 
   @Override
@@ -75,13 +75,13 @@ public class DirectEventEmitter implements EventEmitter {
       return;
     }
 
+    sequenceNumber++;
     try {
       consumer.applyDML(new Sequenced<>(event, sequenceNumber));
     } catch (Exception e) {
       // TODO: (CDAP-16251) retry
       throw new RuntimeException(e);
     }
-    sequenceNumber++;
   }
 
   private boolean shouldIgnore(DDLEvent event) {

--- a/delta-app/src/main/java/io/cdap/delta/app/OffsetAndSequence.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/OffsetAndSequence.java
@@ -14,32 +14,27 @@
  * the License.
  */
 
-package io.cdap.delta.api;
+package io.cdap.delta.app;
 
-import io.cdap.cdap.api.metrics.Metrics;
-import io.cdap.cdap.api.plugin.PluginContext;
-
-import java.io.IOException;
-import javax.annotation.Nullable;
+import io.cdap.delta.api.Offset;
 
 /**
- * Runtime context for a CDC component.
+ * An offset and sequence number.
  */
-public interface DeltaRuntimeContext extends PluginContext {
+public class OffsetAndSequence {
+  private final Offset offset;
+  private final long sequenceNumber;
 
-  /**
-   * @return the application name
-   */
-  String getApplicationName();
+  public OffsetAndSequence(Offset offset, long sequenceNumber) {
+    this.offset = offset;
+    this.sequenceNumber = sequenceNumber;
+  }
 
-  /**
-   * @return the program run id
-   */
-  String getRunId();
+  public Offset getOffset() {
+    return offset;
+  }
 
-  /**
-   * @return metrics emitter
-   */
-  Metrics getMetrics();
-
+  public long getSequenceNumber() {
+    return sequenceNumber;
+  }
 }

--- a/delta-app/src/main/java/io/cdap/delta/app/PipelineStateService.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/PipelineStateService.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app;
+
+import com.google.gson.Gson;
+import io.cdap.cdap.api.common.Bytes;
+import io.cdap.delta.api.ReplicationError;
+import io.cdap.delta.proto.DBTable;
+import io.cdap.delta.proto.PipelineReplicationState;
+import io.cdap.delta.proto.PipelineState;
+import io.cdap.delta.proto.TableReplicationState;
+import io.cdap.delta.proto.TableState;
+import io.cdap.delta.store.StateStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Stores information about pipeline and table state.
+ */
+public class PipelineStateService {
+  private static final Logger LOG = LoggerFactory.getLogger(PipelineStateService.class);
+  private static final Gson GSON = new Gson();
+  private static final String STATE_KEY = "pipeline";
+  private final DeltaPipelineId pipelineId;
+  private final StateStore stateStore;
+  private final Map<DBTable, TableReplicationState> tables;
+  private PipelineState sourceState;
+  private ReplicationError sourceError;
+
+  public PipelineStateService(DeltaPipelineId pipelineId, StateStore stateStore) {
+    this.pipelineId = pipelineId;
+    this.stateStore = stateStore;
+    this.tables = new HashMap<>();
+  }
+
+  public void initialize() throws IOException {
+    byte[] bytes = stateStore.readState(pipelineId, STATE_KEY);
+    if (bytes == null) {
+      sourceState = PipelineState.OK;
+      sourceError = null;
+    } else {
+      PipelineReplicationState replState = GSON.fromJson(Bytes.toString(stateStore.readState(pipelineId, STATE_KEY)),
+                                                         PipelineReplicationState.class);
+      sourceState = replState.getSourceState();
+      sourceError = replState.getSourceError();
+      tables.putAll(replState.getTables().stream()
+                      .collect(Collectors.toMap(t -> new DBTable(t.getDatabase(), t.getTable()), t -> t)));
+    }
+  }
+
+  public PipelineReplicationState getState() {
+    return new PipelineReplicationState(sourceState, new HashSet<>(tables.values()), sourceError);
+  }
+
+  public synchronized void setSourceError(ReplicationError error) {
+    setSourceState(PipelineState.ERROR, error);
+  }
+
+  public synchronized void setSourceOK() {
+    setSourceState(PipelineState.OK, null);
+  }
+
+  public synchronized void setTableSnapshotting(DBTable dbTable) {
+    setTableState(dbTable, new TableReplicationState(dbTable.getDatabase(), dbTable.getTable(),
+                                                     TableState.SNAPSHOT, null));
+  }
+
+  public synchronized void setTableReplicating(DBTable dbTable) {
+    setTableState(dbTable, new TableReplicationState(dbTable.getDatabase(), dbTable.getTable(),
+                                                     TableState.REPLICATE, null));
+  }
+
+  public synchronized void setTableError(DBTable dbTable, ReplicationError error) {
+    setTableState(dbTable, new TableReplicationState(dbTable.getDatabase(), dbTable.getTable(),
+                                                     TableState.ERROR, error));
+  }
+
+  public synchronized void dropTable(DBTable dbTable) {
+    if (tables.remove(dbTable) != null) {
+      save();
+    }
+  }
+
+  private void setSourceState(PipelineState state, ReplicationError error) {
+    boolean shouldSave = sourceState != state;
+    sourceState = state;
+    sourceError = error;
+    if (shouldSave) {
+      save();
+    }
+  }
+
+  private void setTableState(DBTable dbTable, TableReplicationState newState) {
+    TableReplicationState oldState = tables.put(dbTable, newState);
+    if (!newState.equals(oldState)) {
+      save();
+    }
+  }
+
+  private void save() {
+    try {
+      stateStore.writeState(pipelineId, STATE_KEY, Bytes.toBytes(GSON.toJson(getState())));
+    } catch (IOException e) {
+      // TODO: (CDAP-16251) retry failures
+      LOG.warn("Unable to save pipeline replication state.", e);
+    }
+  }
+
+}

--- a/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentService.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentService.java
@@ -24,11 +24,16 @@ import io.cdap.delta.store.DraftStore;
  */
 public class AssessmentService extends AbstractSystemService {
   static final String NAME = "assessor";
+  private final String offsetBasePath;
+
+  public AssessmentService(String offsetBasePath) {
+    this.offsetBasePath = offsetBasePath;
+  }
 
   @Override
   protected void configure() {
     setName(NAME);
-    addHandler(new AssessmentHandler());
+    addHandler(new AssessmentHandler(offsetBasePath));
     createTable(DraftStore.TABLE_SPEC);
   }
 }

--- a/delta-app/src/test/java/io/cdap/delta/app/DirectEventEmitterTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/DirectEventEmitterTest.java
@@ -63,8 +63,8 @@ public class DirectEventEmitterTest {
     emitter.emit(DDL);
     emitter.emit(DML);
 
-    Assert.assertEquals(Collections.singletonList(new Sequenced<>(DDL, 0L)), trackingEventConsumer.getDdlEvents());
-    Assert.assertEquals(Collections.singletonList(new Sequenced<>(DML, 1L)), trackingEventConsumer.getDmlEvents());
+    Assert.assertEquals(Collections.singletonList(new Sequenced<>(DDL, 1L)), trackingEventConsumer.getDdlEvents());
+    Assert.assertEquals(Collections.singletonList(new Sequenced<>(DML, 2L)), trackingEventConsumer.getDmlEvents());
   }
 
   @Test

--- a/delta-proto/src/main/java/io/cdap/delta/proto/PipelineReplicationState.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/PipelineReplicationState.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import io.cdap.delta.api.ReplicationError;
+
+import java.util.Collection;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+/**
+ * State of the overall replication pipeline.
+ */
+public class PipelineReplicationState {
+  private final Set<TableReplicationState> tables;
+  private final PipelineState sourceState;
+  private final ReplicationError sourceError;
+
+  public PipelineReplicationState(PipelineState sourceState, Set<TableReplicationState> tables,
+                                  @Nullable ReplicationError error) {
+    this.sourceState = sourceState;
+    this.tables = tables;
+    this.sourceError = error;
+  }
+
+  public PipelineState getSourceState() {
+    return sourceState;
+  }
+
+  public Set<TableReplicationState> getTables() {
+    return tables;
+  }
+
+  @Nullable
+  public ReplicationError getSourceError() {
+    return sourceError;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PipelineReplicationState that = (PipelineReplicationState) o;
+    return sourceState == that.sourceState &&
+      Objects.equals(tables, that.tables) &&
+      Objects.equals(sourceError, that.sourceError);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(sourceState, tables, sourceError);
+  }
+}

--- a/delta-proto/src/main/java/io/cdap/delta/proto/PipelineState.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/PipelineState.java
@@ -14,32 +14,12 @@
  * the License.
  */
 
-package io.cdap.delta.api;
-
-import io.cdap.cdap.api.metrics.Metrics;
-import io.cdap.cdap.api.plugin.PluginContext;
-
-import java.io.IOException;
-import javax.annotation.Nullable;
+package io.cdap.delta.proto;
 
 /**
- * Runtime context for a CDC component.
+ * State for the overall replication pipeline.
  */
-public interface DeltaRuntimeContext extends PluginContext {
-
-  /**
-   * @return the application name
-   */
-  String getApplicationName();
-
-  /**
-   * @return the program run id
-   */
-  String getRunId();
-
-  /**
-   * @return metrics emitter
-   */
-  Metrics getMetrics();
-
+public enum PipelineState {
+  OK,
+  ERROR
 }

--- a/delta-proto/src/main/java/io/cdap/delta/proto/TableReplicationState.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/TableReplicationState.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import io.cdap.delta.api.ReplicationError;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * State of replication for a table.
+ */
+public class TableReplicationState {
+  private final String database;
+  private final String table;
+  private final TableState state;
+  private final ReplicationError error;
+
+  public TableReplicationState(String database, String table, TableState state, @Nullable ReplicationError error) {
+    this.database = database;
+    this.table = table;
+    this.state = state;
+    this.error = error;
+  }
+
+  public String getDatabase() {
+    return database;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  public TableState getState() {
+    return state;
+  }
+
+  public ReplicationError getError() {
+    return error;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TableReplicationState that = (TableReplicationState) o;
+    return Objects.equals(database, that.database) &&
+      Objects.equals(table, that.table) &&
+      state == that.state &&
+      Objects.equals(error, that.error);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(database, table, state, error);
+  }
+}

--- a/delta-proto/src/main/java/io/cdap/delta/proto/TableState.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/TableState.java
@@ -14,32 +14,13 @@
  * the License.
  */
 
-package io.cdap.delta.api;
-
-import io.cdap.cdap.api.metrics.Metrics;
-import io.cdap.cdap.api.plugin.PluginContext;
-
-import java.io.IOException;
-import javax.annotation.Nullable;
+package io.cdap.delta.proto;
 
 /**
- * Runtime context for a CDC component.
+ * State of a table.
  */
-public interface DeltaRuntimeContext extends PluginContext {
-
-  /**
-   * @return the application name
-   */
-  String getApplicationName();
-
-  /**
-   * @return the program run id
-   */
-  String getRunId();
-
-  /**
-   * @return metrics emitter
-   */
-  Metrics getMetrics();
-
+public enum TableState {
+  SNAPSHOT,
+  REPLICATE,
+  ERROR
 }

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/FileEventConsumer.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/FileEventConsumer.java
@@ -51,7 +51,7 @@ public class FileEventConsumer implements EventConsumer {
   private final List<ChangeEvent> events;
   private final DeltaTargetContext context;
 
-  public FileEventConsumer(File file, DeltaTargetContext context) {
+  FileEventConsumer(File file, DeltaTargetContext context) {
     this.file = file;
     this.events = new ArrayList<>();
     this.context = context;
@@ -75,14 +75,15 @@ public class FileEventConsumer implements EventConsumer {
   public void applyDDL(Sequenced<DDLEvent> event) throws IOException {
     events.add(event.getEvent());
     context.incrementCount(event.getEvent().getOperation());
-    context.commitOffset(event.getEvent().getOffset());
+    context.commitOffset(event.getEvent().getOffset(), event.getSequenceNumber());
+    context.setTableReplicating(event.getEvent().getDatabase(), event.getEvent().getTable());
   }
 
   @Override
   public void applyDML(Sequenced<DMLEvent> event) throws IOException {
     events.add(event.getEvent());
     context.incrementCount(event.getEvent().getOperation());
-    context.commitOffset(event.getEvent().getOffset());
+    context.commitOffset(event.getEvent().getOffset(), event.getSequenceNumber());
   }
 
   /**

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockEventReader.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockEventReader.java
@@ -16,10 +16,6 @@
 
 package io.cdap.delta.test.mock;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import io.cdap.cdap.api.data.schema.Schema;
-import io.cdap.cdap.internal.io.SchemaTypeAdapter;
 import io.cdap.delta.api.ChangeEvent;
 import io.cdap.delta.api.DDLEvent;
 import io.cdap.delta.api.DMLEvent;
@@ -35,10 +31,6 @@ import java.util.List;
  * A mock event reader that emits a pre-specified list of events.
  */
 public class MockEventReader implements EventReader {
-  private static final Gson GSON = new GsonBuilder()
-    .registerTypeAdapter(Schema.class, new SchemaTypeAdapter())
-    .registerTypeAdapter(ChangeEvent.class, new ChangeEventDeserializer())
-    .create();
   private final List<? extends ChangeEvent> events;
   private final EventEmitter emitter;
   private final int maxEvents;


### PR DESCRIPTION
Added methods to the source and target contexts to allow them to
record state information. The source can record that the pipeline
is snapshotting, replicating, or failing. The target can record
that specific tables are ok or failing. If something is failing,
a replication error containing a message and a stack trace can
also be provided.

Also added a REST endpoint to get the state for a pipeline.