### PR TITLE
CDAP-16313 add parallelism

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaRuntimeContext.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaRuntimeContext.java
@@ -43,6 +43,11 @@ public interface DeltaRuntimeContext extends PluginContext {
   Metrics getMetrics();
 
   /**
+   * @return id of the worker instance.
+   */
+  int getInstanceId();
+
+  /**
    * @return maximum amount of seconds to retry failures before failing the pipeline
    */
   int getMaxRetrySeconds();

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaApp.java
@@ -50,7 +50,7 @@ public class DeltaApp extends AbstractApplication<DeltaConfig> {
     DeltaTarget target = registerPlugin(targetConf);
     target.configure(configurer);
 
-    addWorker(new DeltaWorker());
+    addWorker(new DeltaWorker(conf));
 
     String description = conf.getDescription();
     if (description == null) {

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
@@ -29,8 +29,6 @@ import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.ReplicationError;
 import io.cdap.delta.proto.DBTable;
 import io.cdap.delta.store.StateStore;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -41,8 +39,7 @@ import javax.annotation.Nullable;
  */
 public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
   private static final String STATE_PREFIX = "state-";
-  private static final Logger LOG = LoggerFactory.getLogger(DeltaContext.class);
-  private final DeltaPipelineId id;
+  private final DeltaWorkerId id;
   private final String runId;
   private final Metrics metrics;
   private final StateStore stateStore;
@@ -51,7 +48,7 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
   private final PipelineStateService stateService;
   private final int maxRetrySeconds;
 
-  DeltaContext(DeltaPipelineId id, String runId, Metrics metrics, StateStore stateStore,
+  DeltaContext(DeltaWorkerId id, String runId, Metrics metrics, StateStore stateStore,
                PluginContext pluginContext, EventMetrics eventMetrics, PipelineStateService stateService,
                int maxRetrySeconds) {
     this.id = id;
@@ -107,7 +104,7 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
 
   @Override
   public String getApplicationName() {
-    return id.getApp();
+    return id.getPipelineId().getApp();
   }
 
   @Override
@@ -118,6 +115,11 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
   @Override
   public Metrics getMetrics() {
     return metrics;
+  }
+
+  @Override
+  public int getInstanceId() {
+    return id.getInstanceId();
   }
 
   @Override

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaWorkerId.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaWorkerId.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app;
+
+import java.util.Objects;
+
+/**
+ * Uniquely identifies a worker instance.
+ */
+public class DeltaWorkerId {
+  private final DeltaPipelineId pipelineId;
+  private final int instanceId;
+
+  public DeltaWorkerId(DeltaPipelineId pipelineId, int instanceId) {
+    this.pipelineId = pipelineId;
+    this.instanceId = instanceId;
+  }
+
+  public DeltaPipelineId getPipelineId() {
+    return pipelineId;
+  }
+
+  public int getInstanceId() {
+    return instanceId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeltaWorkerId that = (DeltaWorkerId) o;
+    return instanceId == that.instanceId &&
+      Objects.equals(pipelineId, that.pipelineId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(pipelineId, instanceId);
+  }
+}

--- a/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
@@ -85,7 +85,10 @@ public class QueueingEventEmitter implements EventEmitter {
     }
 
     SourceTable sourceTable = tableDefinitions.get(new DBTable(event.getDatabase(), event.getTable()));
-    return sourceTable != null && sourceTable.getDdlBlacklist().contains(event.getOperation());
+    if (sourceTable != null && sourceTable.getDdlBlacklist().contains(event.getOperation())) {
+      return true;
+    }
+    return !tableDefinitions.isEmpty() && sourceTable == null;
   }
 
   private boolean shouldIgnore(DMLEvent event) {
@@ -94,6 +97,9 @@ public class QueueingEventEmitter implements EventEmitter {
     }
 
     SourceTable sourceTable = tableDefinitions.get(new DBTable(event.getDatabase(), event.getTable()));
-    return sourceTable != null && sourceTable.getDmlBlacklist().contains(event.getOperation());
+    if (sourceTable != null && sourceTable.getDmlBlacklist().contains(event.getOperation())) {
+      return true;
+    }
+    return !tableDefinitions.isEmpty() && sourceTable == null;
   }
 }

--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -244,11 +244,11 @@ public class DraftService {
     List<TableSummaryAssessment> tableAssessments = new ArrayList<>();
 
     // if no source tables are given, this means all tables should be read
-    Set<SourceTable> tablesToAssess = deltaConfig.getTables();
+    List<SourceTable> tablesToAssess = deltaConfig.getTables();
     if (tablesToAssess.isEmpty()) {
       tablesToAssess = tableRegistry.listTables().getTables().stream()
         .map(t -> new SourceTable(t.getDatabase(), t.getTable()))
-        .collect(Collectors.toSet());
+        .collect(Collectors.toList());
     }
 
     // go through all tables that the pipeline should read, fetching detail about each of the tables

--- a/delta-app/src/test/java/io/cdap/delta/app/DeltaWorkerTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/DeltaWorkerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app;
+
+import io.cdap.delta.api.DeltaSource;
+import io.cdap.delta.api.DeltaTarget;
+import io.cdap.delta.api.SourceTable;
+import io.cdap.delta.proto.Artifact;
+import io.cdap.delta.proto.DeltaConfig;
+import io.cdap.delta.proto.InstanceConfig;
+import io.cdap.delta.proto.ParallelismConfig;
+import io.cdap.delta.proto.Plugin;
+import io.cdap.delta.proto.Stage;
+import io.cdap.delta.proto.TableId;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tests for {@link DeltaWorker}.
+ */
+public class DeltaWorkerTest {
+  private static final SourceTable TABLE1 = new SourceTable("db", "t1");
+  private static final SourceTable TABLE2 = new SourceTable("db", "t2");
+  private static final SourceTable TABLE3 = new SourceTable("db", "t3");
+  private static final SourceTable TABLE4 = new SourceTable("db", "t4");
+  private static final TableId TABLE1_ID = new TableId(TABLE1.getDatabase(), TABLE1.getTable(), TABLE1.getSchema());
+  private static final TableId TABLE2_ID = new TableId(TABLE2.getDatabase(), TABLE2.getTable(), TABLE2.getSchema());
+  private static final TableId TABLE3_ID = new TableId(TABLE3.getDatabase(), TABLE3.getTable(), TABLE3.getSchema());
+  private static final TableId TABLE4_ID = new TableId(TABLE4.getDatabase(), TABLE4.getTable(), TABLE4.getSchema());
+
+  @Test
+  public void testAssignTablesByInstanceCount() {
+    DeltaConfig config = DeltaConfig.builder()
+      .setSource(new Stage("src", new Plugin("mysql", DeltaSource.PLUGIN_TYPE, Collections.emptyMap(), Artifact.EMPTY)))
+      .setTarget(new Stage("tgt", new Plugin("bq", DeltaTarget.PLUGIN_TYPE, Collections.emptyMap(), Artifact.EMPTY)))
+      .setParallelism(new ParallelismConfig(3))
+      .setTables(Arrays.asList(TABLE1, TABLE2, TABLE3, TABLE4))
+      .build();
+    Map<Integer, Set<TableId>> expected = new HashMap<>();
+    expected.put(0, new HashSet<>(Arrays.asList(TABLE1_ID, TABLE4_ID)));
+    expected.put(1, Collections.singleton(TABLE2_ID));
+    expected.put(2, Collections.singleton(TABLE3_ID));
+    Assert.assertEquals(expected, DeltaWorker.assignTables(config));
+  }
+
+  @Test
+  public void testAssignTablesFewerTablesThanInstances() {
+    DeltaConfig config = DeltaConfig.builder()
+      .setSource(new Stage("src", new Plugin("mysql", DeltaSource.PLUGIN_TYPE, Collections.emptyMap(), Artifact.EMPTY)))
+      .setTarget(new Stage("tgt", new Plugin("bq", DeltaTarget.PLUGIN_TYPE, Collections.emptyMap(), Artifact.EMPTY)))
+      .setParallelism(new ParallelismConfig(3))
+      .setTables(Arrays.asList(TABLE1, TABLE2))
+      .build();
+    Map<Integer, Set<TableId>> expected = new HashMap<>();
+    expected.put(0, Collections.singleton(TABLE1_ID));
+    expected.put(1, Collections.singleton(TABLE2_ID));
+    Assert.assertEquals(expected, DeltaWorker.assignTables(config));
+  }
+
+  @Test
+  public void testAssignTablesDirectly() {
+    Set<TableId> instance0Tables = new HashSet<>();
+    instance0Tables.add(TABLE1_ID);
+    instance0Tables.add(TABLE2_ID);
+    instance0Tables.add(TABLE3_ID);
+    Set<TableId> instance1Tables = new HashSet<>();
+    instance1Tables.add(TABLE4_ID);
+
+    DeltaConfig config = DeltaConfig.builder()
+      .setSource(new Stage("src", new Plugin("mysql", DeltaSource.PLUGIN_TYPE, Collections.emptyMap(), Artifact.EMPTY)))
+      .setTarget(new Stage("tgt", new Plugin("bq", DeltaTarget.PLUGIN_TYPE, Collections.emptyMap(), Artifact.EMPTY)))
+      .setParallelism(new ParallelismConfig(Arrays.asList(new InstanceConfig(instance0Tables),
+                                                          new InstanceConfig(instance1Tables))))
+      .setTables(Arrays.asList(TABLE1, TABLE2, TABLE3, TABLE4))
+      .build();
+
+    Map<Integer, Set<TableId>> expected = new HashMap<>();
+    expected.put(0, instance0Tables);
+    expected.put(1, instance1Tables);
+    Map<Integer, Set<TableId>> assignments = DeltaWorker.assignTables(config);
+    Assert.assertEquals(expected, assignments);
+  }
+}

--- a/delta-proto/src/main/java/io/cdap/delta/proto/InstanceConfig.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/InstanceConfig.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Information about a single instance of the worker.
+ */
+public class InstanceConfig {
+  private final Set<TableId> tables;
+
+  public InstanceConfig(Set<TableId> tables) {
+    this.tables = new HashSet<>(tables);
+  }
+
+  public Set<TableId> getTables() {
+    return tables == null ? Collections.emptySet() : Collections.unmodifiableSet(tables);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    InstanceConfig that = (InstanceConfig) o;
+    return Objects.equals(tables, that.tables);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tables);
+  }
+}

--- a/delta-proto/src/main/java/io/cdap/delta/proto/ParallelismConfig.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/ParallelismConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Configures the number of instances, or specify exactly which tables should be assigned to each instance.
+ */
+public class ParallelismConfig {
+  public static final ParallelismConfig DEFAULT = new ParallelismConfig(1, Collections.emptyList());
+  private final Integer numInstances;
+  private final List<InstanceConfig> instances;
+
+  public ParallelismConfig(int numInstances) {
+    this(numInstances, Collections.emptyList());
+  }
+
+  public ParallelismConfig(List<InstanceConfig> instances) {
+    this(null, instances);
+  }
+
+  private ParallelismConfig(Integer numInstances, List<InstanceConfig> instances) {
+    this.numInstances = numInstances;
+    this.instances = instances;
+  }
+
+  @Nullable
+  public Integer getNumInstances() {
+    return numInstances;
+  }
+
+  public List<InstanceConfig> getInstances() {
+    return instances == null ? Collections.emptyList() : Collections.unmodifiableList(instances);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ParallelismConfig that = (ParallelismConfig) o;
+    return numInstances == that.numInstances &&
+      Objects.equals(getInstances(), that.getInstances());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(numInstances, instances);
+  }
+}

--- a/delta-proto/src/main/java/io/cdap/delta/proto/PipelineReplicationState.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/PipelineReplicationState.java
@@ -18,7 +18,7 @@ package io.cdap.delta.proto;
 
 import io.cdap.delta.api.ReplicationError;
 
-import java.util.Collection;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
  * State of the overall replication pipeline.
  */
 public class PipelineReplicationState {
+  public static final PipelineReplicationState EMPTY =
+    new PipelineReplicationState(PipelineState.OK, Collections.emptySet(), null);
   private final Set<TableReplicationState> tables;
   private final PipelineState sourceState;
   private final ReplicationError sourceError;

--- a/delta-proto/src/main/java/io/cdap/delta/proto/TableId.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/TableId.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.proto;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/**
+ * Uniquely identifies a table.
+ */
+public class TableId {
+  private final String database;
+  private final String table;
+  // this schema is required for some db to uniquely identify the table, if this is not provided, it will not
+  // be able to fetch the records
+  // TODO: CDAP-16261 have a better way to identify the table
+  private final String schema;
+
+  public TableId(String database, String table, @Nullable String schema) {
+    this.database = database;
+    this.table = table;
+    this.schema = schema;
+  }
+
+  public String getDatabase() {
+    return database;
+  }
+
+  public String getTable() {
+    return table;
+  }
+
+  @Nullable
+  public String getSchema() {
+    return schema;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TableId tableId = (TableId) o;
+    return Objects.equals(database, tableId.database) &&
+      Objects.equals(table, tableId.table) &&
+      Objects.equals(schema, tableId.schema);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(database, table, schema);
+  }
+}

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/FileEventConsumer.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/FileEventConsumer.java
@@ -67,7 +67,7 @@ public class FileEventConsumer implements EventConsumer {
     try (FileWriter writer = new FileWriter(file)) {
       writer.write(GSON.toJson(events));
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException(e.getMessage(), e);
     }
   }
 
@@ -90,14 +90,16 @@ public class FileEventConsumer implements EventConsumer {
    * Read events that were consumed by the target. This should only be called after the pipeline has been stopped.
    *
    * @param filePath path to read events from
+   * @param instanceId instance id that wrote the events
    * @return list of events contained in the file path
    * @throws IOException if there was an issue reading the file
    */
-  public static List<? extends ChangeEvent> readEvents(File filePath) throws IOException {
-    if (!filePath.exists()) {
+  public static List<? extends ChangeEvent> readEvents(File filePath, int instanceId) throws IOException {
+    File eventsFile = new File(filePath, String.format("%d.json", instanceId));
+    if (!eventsFile.exists()) {
       return Collections.emptyList();
     }
-    try (Reader reader = new FileReader(filePath)) {
+    try (Reader reader = new FileReader(eventsFile)) {
       return GSON.fromJson(reader, new TypeToken<List<? extends ChangeEvent>>() { }.getType());
     }
   }

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockTarget.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockTarget.java
@@ -56,7 +56,7 @@ public class MockTarget implements DeltaTarget {
 
   @Override
   public EventConsumer createConsumer(DeltaTargetContext context) {
-    File outputFile = new File(conf.path);
+    File outputFile = new File(new File(conf.path), String.format("%d.json", context.getInstanceId()));
     if (outputFile.exists()) {
       outputFile.delete();
     }
@@ -77,7 +77,8 @@ public class MockTarget implements DeltaTarget {
 
   /**
    * Get the plugin configuration for a mock target that should write events to a local file.
-   * After the pipeline is stopped, use {@link FileEventConsumer#readEvents(File)} to read events written by the target.
+   * After the pipeline is stopped, use {@link FileEventConsumer#readEvents(File, int)}
+   * to read events written by the target.
    *
    * @param filePath path to the file to write events to
    * @return plugin configuration for the mock source


### PR DESCRIPTION
Added a parallelism config to the delta config that lets the user
specify either the number of worker instances to use. At deployment
time, the source tables are assigned to different worker instances
in a round robin fashion. Alternatively, the user can also manually
provide the table assignments instead of just the number of worker
instances.

Refactored the worker such that each worker instance only reads and
applies changes to its assigned set of tables. Offsets, sequence
numbers, and state were all changed to be per worker instance.

Currently, there is no way to change the number of instances
after the app is deployed, due to the tables being assigned at
deployment time and because there isn't currently a way to merge
different instance offsets/states.