### PR TITLE
CDAP-16343 fix filesystem usage

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
@@ -155,9 +155,8 @@ public class DeltaWorker extends AbstractWorker {
     DeltaWorkerId id = new DeltaWorkerId(new DeltaPipelineId(context.getNamespace(), appSpec.getName(), generation),
                                          context.getInstanceId());
 
-    FileSystem fs = FileSystem.get(new Configuration());
     Path path = new Path(offsetBasePath);
-    StateStore stateStore = new StateStore(fs, path);
+    StateStore stateStore = StateStore.from(path);
     EventMetrics eventMetrics = new EventMetrics(metrics, targetName);
     PipelineStateService stateService = new PipelineStateService(id, stateStore);
     stateService.load();

--- a/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentHandler.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentHandler.java
@@ -231,9 +231,8 @@ public class AssessmentHandler extends AbstractSystemHttpServiceHandler {
                        @PathParam("pipeline") String pipelineName) {
     respond(namespaceName, responder, ((draftService, namespace) -> {
       String offsetBasePath = getContext().getSpecification().getProperty(OFFSET_PATH);
-      FileSystem fs = FileSystem.get(new Configuration());
       org.apache.hadoop.fs.Path path = new org.apache.hadoop.fs.Path(offsetBasePath);
-      StateStore stateStore = new StateStore(fs, path);
+      StateStore stateStore = StateStore.from(path);
 
       Long latestGen = stateStore.getLatestGeneration(namespaceName, pipelineName);
       // this can happen if the pipeline was never started

--- a/delta-app/src/main/java/io/cdap/delta/store/StateStore.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/StateStore.java
@@ -21,6 +21,7 @@ import io.cdap.delta.api.Offset;
 import io.cdap.delta.app.DeltaPipelineId;
 import io.cdap.delta.app.DeltaWorkerId;
 import io.cdap.delta.app.OffsetAndSequence;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -44,9 +45,13 @@ public class StateStore {
   private final FileSystem fileSystem;
   private final Path basePath;
 
-  public StateStore(FileSystem fileSystem, Path basePath) {
+  private StateStore(FileSystem fileSystem, Path basePath) {
     this.fileSystem = fileSystem;
     this.basePath = basePath;
+  }
+
+  public static StateStore from(Path basePath) throws IOException {
+    return new StateStore(basePath.getFileSystem(new Configuration()), basePath);
   }
 
   @Nullable

--- a/delta-app/src/test/java/io/cdap/delta/app/DeltaPipelineTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/DeltaPipelineTest.java
@@ -141,7 +141,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
 
     FileSystem fs = FileSystem.get(new Configuration());
     Path path = new Path(offsetBasePath);
-    StateStore stateStore = new StateStore(fs, path);
+    StateStore stateStore = StateStore.from(path);
     Long generation = stateStore.getLatestGeneration(appId.getNamespace(), appId.getApplication());
     DeltaPipelineId pipelineId = new DeltaPipelineId(appId.getNamespace(), appId.getApplication(), generation);
     DeltaWorkerId workerId = new DeltaWorkerId(pipelineId, 0);
@@ -189,7 +189,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
 
     FileSystem fs = FileSystem.get(new Configuration());
     Path path = new Path(offsetBasePath);
-    StateStore stateStore = new StateStore(fs, path);
+    StateStore stateStore = StateStore.from(path);
     Long generation = stateStore.getLatestGeneration(appId.getNamespace(), appId.getApplication());
     DeltaPipelineId pipelineId = new DeltaPipelineId(appId.getNamespace(), appId.getApplication(), generation);
     DeltaWorkerId workerId = new DeltaWorkerId(pipelineId, 0);
@@ -284,7 +284,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
     // wait for the replication state for the table to be set to ERROR.
     FileSystem fs = FileSystem.get(new Configuration());
     Path path = new Path(offsetBasePath);
-    StateStore stateStore = new StateStore(fs, path);
+    StateStore stateStore = StateStore.from(path);
     Long generation = stateStore.getLatestGeneration(appId.getNamespace(), appId.getApplication());
     DeltaPipelineId pipelineId = new DeltaPipelineId(appId.getNamespace(), appId.getApplication(), generation);
     DeltaWorkerId workerId = new DeltaWorkerId(pipelineId, 0);
@@ -376,7 +376,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
 
     FileSystem fs = FileSystem.get(new Configuration());
     Path path = new Path(offsetBasePath);
-    StateStore stateStore = new StateStore(fs, path);
+    StateStore stateStore = StateStore.from(path);
     Long generation = stateStore.getLatestGeneration(appId.getNamespace(), appId.getApplication());
     DeltaPipelineId pipelineId = new DeltaPipelineId(appId.getNamespace(), appId.getApplication(), generation);
     Collection<Integer> instanceIds = stateStore.getWorkerInstances(pipelineId);


### PR DESCRIPTION
Create the FileSystem object using the URI from the path instead
of getting the default FileSystem. This properly allows it to
use a distributed filesystem instead of the local one.