### PR TITLE
CDAP-16346 added a way for sources to notify failures

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaSourceContext.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaSourceContext.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 /**
  * Context for a CDC Source.
  */
-public interface DeltaSourceContext extends DeltaRuntimeContext {
+public interface DeltaSourceContext extends DeltaRuntimeContext, FailureNotifier {
 
   /**
    * Record that there are currently errors reading change events.

--- a/delta-api/src/main/java/io/cdap/delta/api/EventConsumer.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/EventConsumer.java
@@ -31,7 +31,9 @@ public interface EventConsumer {
    *
    * @throws InterruptedException if the consumer was interrupted while stopping
    */
-  void stop() throws InterruptedException;
+  default void stop() throws InterruptedException {
+    // no-op
+  }
 
   /**
    * Apply a DDL event, such as creating a table. This method must be idempotent. For example, if the event is a table

--- a/delta-api/src/main/java/io/cdap/delta/api/FailureNotifier.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/FailureNotifier.java
@@ -17,21 +17,20 @@
 package io.cdap.delta.api;
 
 /**
- * Reads change events.
+ * Notifies the application framework that there is a failure.
  */
-public interface EventReader {
+public interface FailureNotifier {
 
   /**
-   * Start reading events from the given offset.
-   */
-  void start(Offset offset);
-
-  /**
-   * Stop reading events.
+   * Call this method if a failure was encountered.
+   * In the event of a failure, the application framework will stop the EventReader and EventConsumer,
+   * create new ones, then restart from the last committed offset.
+   * This will be retried up to the retry timeout configured for the program.
    *
-   * @throws InterruptedException if the reader was interrupted while stopping
+   * If the cause is a {@link DeltaFailureException}, the program will be failed immediately instead of retried.
+   *
+   * @param cause cause of the failure
    */
-  default void stop() throws InterruptedException {
-    // no-op
-  }
+  void notifyFailed(Throwable cause);
+
 }

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/FailureEventReader.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/FailureEventReader.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.test.mock;
+
+import io.cdap.delta.api.DeltaSourceContext;
+import io.cdap.delta.api.EventReader;
+import io.cdap.delta.api.Offset;
+import io.cdap.delta.api.ReplicationError;
+
+import java.io.IOException;
+
+/**
+ * An event reader that immediately notifies the framework that there is an error.
+ */
+public class FailureEventReader implements EventReader {
+  private final DeltaSourceContext context;
+
+  FailureEventReader(DeltaSourceContext context) {
+    this.context = context;
+  }
+
+  @Override
+  public void start(Offset offset) {
+    RuntimeException exception = new RuntimeException("Source was configured to fail");
+    try {
+      context.setError(new ReplicationError(exception));
+    } catch (IOException e) {
+      // shouldn't happen in unit tests
+    }
+    context.notifyFailed(exception);
+  }
+}

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockEventReader.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockEventReader.java
@@ -64,11 +64,6 @@ public class MockEventReader implements EventReader {
     }
   }
 
-  @Override
-  public void stop() {
-    // no-op
-  }
-
   private boolean offsetsEqual(Offset o1, Offset o2) {
     if (!o1.get().keySet().equals(o2.get().keySet())) {
       return false;


### PR DESCRIPTION
Added a notifyFailure method to the DeltaSourceContext that allows
an EventReader to notify the app that it is failing and tell the
app to reset state to the last committed offset.