### PR TITLE
CDAP-16475 Filter out unselected primary keys for table detail before passing to table assessment

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -290,12 +290,16 @@ public class DraftService {
 
     // fetch detail about the table, then filter out columns that will not be read by the source
     TableDetail detail = tableRegistry.describeTable(db, table);
+    List<String> selectedPrimaryKeys = detail.getPrimaryKey().stream()
+      // if there are no columns specified, it means all columns (including primary keys) should be read
+      .filter(columnWhitelist.isEmpty() ? col -> true : columnWhitelist::contains)
+      .collect(Collectors.toList());
     List<ColumnDetail> selectedColumns = detail.getColumns().stream()
       // if there are no columns specified, it means all columns should be read
       .filter(columnWhitelist.isEmpty() ? col -> true : col -> columnWhitelist.contains(col.getName()))
       .collect(Collectors.toList());
     TableDetail filteredDetail = TableDetail.builder(db, table, detail.getSchema())
-      .setPrimaryKey(detail.getPrimaryKey())
+      .setPrimaryKey(selectedPrimaryKeys)
       .setColumns(selectedColumns)
       .setFeatures(detail.getFeatures())
       .build();

--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -290,18 +290,26 @@ public class DraftService {
 
     // fetch detail about the table, then filter out columns that will not be read by the source
     TableDetail detail = tableRegistry.describeTable(db, table);
-    List<String> selectedPrimaryKeys = detail.getPrimaryKey().stream()
-      // if there are no columns specified, it means all columns (including primary keys) should be read
-      .filter(columnWhitelist.isEmpty() ? col -> true : columnWhitelist::contains)
-      .collect(Collectors.toList());
+    List<Problem> missingFeatures = new ArrayList<>(detail.getFeatures());
+    detail.getPrimaryKey().stream()
+      // if there are no columns specified, it means this primary key will be read/selected
+      .filter(columnWhitelist.isEmpty() ? col -> false : col -> !columnWhitelist.contains(col))
+      // add feature problem for any unselected primary key for table
+      .forEach(col -> missingFeatures.add(
+        new Problem("Missing Primary Key",
+                    String.format("Column '%s' is part of the primary key for table '%s' in database '%s', but is " +
+                                    "not one of the selected columns to be replicated", col, detail.getTable(),
+                                  detail.getDatabase()),
+                    "Please make sure this column has been selected",
+                    "This can result in different data at the target than at the source")));
     List<ColumnDetail> selectedColumns = detail.getColumns().stream()
       // if there are no columns specified, it means all columns should be read
       .filter(columnWhitelist.isEmpty() ? col -> true : col -> columnWhitelist.contains(col.getName()))
       .collect(Collectors.toList());
     TableDetail filteredDetail = TableDetail.builder(db, table, detail.getSchema())
-      .setPrimaryKey(selectedPrimaryKeys)
+      .setPrimaryKey(detail.getPrimaryKey())
       .setColumns(selectedColumns)
-      .setFeatures(detail.getFeatures())
+      .setFeatures(missingFeatures)
       .build();
     TableAssessment srcAssessment = sourceTableAssessor.assess(filteredDetail);
 


### PR DESCRIPTION
The delta app should also favor selected/unselected primary keys and use that to from filtered table detail before passing it for table assessment.

Tested on local, missing primary key showed up correctly if I manually unselected primary key during table listing. 