### PR TITLE
CDAP-16475 Add feature problem for unselected primary key during assessment.

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -290,6 +290,21 @@ public class DraftService {
 
     // fetch detail about the table, then filter out columns that will not be read by the source
     TableDetail detail = tableRegistry.describeTable(db, table);
+    List<Problem> missingFeatures = new ArrayList<>(detail.getFeatures());
+    List<String> unselectedPrimaryKeys = detail.getPrimaryKey().stream()
+      // if there are no columns specified, it means this primary key will be read/selected
+      .filter(columnWhitelist.isEmpty() ? col -> false : col -> !columnWhitelist.contains(col))
+      .collect(Collectors.toList());
+    if (!unselectedPrimaryKeys.isEmpty()) {
+      missingFeatures.add(
+        new Problem("Missing Primary Key",
+                    String.format("Column(s) '%s' is(are) part of the primary key for table '%s' in database '%s', " +
+                                    "but is(are) not selected to be replicated",
+                                  String.join(",", unselectedPrimaryKeys),
+                                  detail.getTable(), detail.getDatabase()),
+                    "Please make sure column(s) been selected",
+                    "This can result in different data at the target than at the source"));
+    }
     List<ColumnDetail> selectedColumns = detail.getColumns().stream()
       // if there are no columns specified, it means all columns should be read
       .filter(columnWhitelist.isEmpty() ? col -> true : col -> columnWhitelist.contains(col.getName()))
@@ -297,7 +312,7 @@ public class DraftService {
     TableDetail filteredDetail = TableDetail.builder(db, table, detail.getSchema())
       .setPrimaryKey(detail.getPrimaryKey())
       .setColumns(selectedColumns)
-      .setFeatures(detail.getFeatures())
+      .setFeatures(missingFeatures)
       .build();
     TableAssessment srcAssessment = sourceTableAssessor.assess(filteredDetail);
 

--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -295,16 +295,25 @@ public class DraftService {
       // if there are no columns specified, it means this primary key will be read/selected
       .filter(columnWhitelist.isEmpty() ? col -> false : col -> !columnWhitelist.contains(col))
       .collect(Collectors.toList());
-    if (!unselectedPrimaryKeys.isEmpty()) {
+    if (unselectedPrimaryKeys.size() == 1) {
       missingFeatures.add(
         new Problem("Missing Primary Key",
-                    String.format("Column(s) '%s' is(are) part of the primary key for table '%s' in database '%s', " +
-                                    "but is(are) not selected to be replicated",
+                    String.format("Column '%s' is part of the primary key for table '%s' in database '%s', " +
+                                    "but is not selected to be replicated", unselectedPrimaryKeys.get(0),
+                                  detail.getTable(), detail.getDatabase()),
+                    "Please make sure this column been selected",
+                    "This can result in different data at the target than at the source"));
+    } else if (unselectedPrimaryKeys.size() > 1) {
+      missingFeatures.add(
+        new Problem("Missing Primary Key",
+                    String.format("Columns '%s' are part of the primary key for table '%s' in database '%s', " +
+                                    "but are not selected to be replicated",
                                   String.join(",", unselectedPrimaryKeys),
                                   detail.getTable(), detail.getDatabase()),
-                    "Please make sure column(s) been selected",
+                    "Please make sure columns been selected",
                     "This can result in different data at the target than at the source"));
     }
+
     List<ColumnDetail> selectedColumns = detail.getColumns().stream()
       // if there are no columns specified, it means all columns should be read
       .filter(columnWhitelist.isEmpty() ? col -> true : col -> columnWhitelist.contains(col.getName()))


### PR DESCRIPTION
The delta app should also check unselected primary keys, if there are, then we should add it as missing feature problem. 

Tested on local, missing primary key showed up correctly if I manually unselected primary key during table listing.
