### PR TITLE
Fixed the issue that delta app will ignore CREATE DATABASE ddl event during snapshotting

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
@@ -170,8 +170,6 @@ public class DeltaWorker extends AbstractWorker {
     Set<DDLOperation> ddlBlacklist = new HashSet<>(config.getDdlBlacklist());
     // targets will not behave properly if they don't get create table events
     ddlBlacklist.remove(DDLOperation.CREATE_TABLE);
-    // blacklist drop database event by default in case that user unintentionally drop database from source
-    ddlBlacklist.add(DDLOperation.DROP_DATABASE);
     Set<SourceTable> expandedTables = config.getTables().stream()
       .filter(t -> assignedTables.contains(new TableId(t.getDatabase(), t.getTable(), t.getSchema())))
       .map(t -> {

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
@@ -170,6 +170,8 @@ public class DeltaWorker extends AbstractWorker {
     Set<DDLOperation> ddlBlacklist = new HashSet<>(config.getDdlBlacklist());
     // targets will not behave properly if they don't get create table events
     ddlBlacklist.remove(DDLOperation.CREATE_TABLE);
+    // blacklist drop database event by default in case that user unintentionally drop database from source
+    ddlBlacklist.add(DDLOperation.DROP_DATABASE);
     Set<SourceTable> expandedTables = config.getTables().stream()
       .filter(t -> assignedTables.contains(new TableId(t.getDatabase(), t.getTable(), t.getSchema())))
       .map(t -> {

--- a/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
@@ -80,17 +80,16 @@ public class QueueingEventEmitter implements EventEmitter {
   }
 
   private boolean shouldIgnore(DDLEvent event) {
-    if (ddlBlacklist.contains(event.getOperation())) {
+    DDLOperation ddlOperation = event.getOperation();
+    if (ddlBlacklist.contains(ddlOperation)) {
       return true;
+    } else if (ddlOperation == DDLOperation.CREATE_DATABASE || ddlOperation == DDLOperation.DROP_DATABASE) {
+      return false;
     }
 
     SourceTable sourceTable = tableDefinitions.get(new DBTable(event.getDatabase(), event.getTable()));
-    if (sourceTable != null && sourceTable.getDdlBlacklist().contains(event.getOperation())) {
+    if (sourceTable != null && sourceTable.getDdlBlacklist().contains(ddlOperation)) {
       return true;
-    }
-
-    if (sourceTable == null && event.getOperation() == DDLOperation.CREATE_DATABASE) {
-      return false;
     }
 
     return !tableDefinitions.isEmpty() && sourceTable == null;

--- a/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
@@ -88,6 +88,11 @@ public class QueueingEventEmitter implements EventEmitter {
     if (sourceTable != null && sourceTable.getDdlBlacklist().contains(event.getOperation())) {
       return true;
     }
+
+    if (sourceTable == null && event.getOperation() == DDLOperation.CREATE_DATABASE) {
+      return false;
+    }
+
     return !tableDefinitions.isEmpty() && sourceTable == null;
   }
 

--- a/delta-proto/src/main/java/io/cdap/delta/proto/DeltaConfig.java
+++ b/delta-proto/src/main/java/io/cdap/delta/proto/DeltaConfig.java
@@ -100,7 +100,9 @@ public class DeltaConfig extends Config {
   }
 
   public Set<DDLOperation> getDdlBlacklist() {
-    return ddlBlacklist == null ? Collections.emptySet() : Collections.unmodifiableSet(ddlBlacklist);
+    // blacklist drop database event by default if ddlBlacklist is null
+    return ddlBlacklist == null ? Collections.singleton(DDLOperation.DROP_DATABASE) :
+      Collections.unmodifiableSet(ddlBlacklist);
   }
 
   /**


### PR DESCRIPTION
1. put DROP_DATABASE ddl operation as blacklisted by default.
2. Do not ignore CREATE_DATABASE event. 

Tested on local, dataset was successfully created in big query target.