### PR TITLE
CDAP-16558 add a way to get general problems from plugins

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/Assessment.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/Assessment.java
@@ -22,23 +22,29 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * An assessment about a potential pipeline, indicating possible errors and fixes for those errors.
+ * A general assessment, containing potential problems.
  */
-public class PipelineAssessment extends Assessment {
-  private final List<TableSummaryAssessment> tables;
+public class Assessment {
+  private final List<Problem> features;
+  private final List<Problem> connectivity;
 
-  public PipelineAssessment(List<TableSummaryAssessment> tables,
-                            List<Problem> featureProblems,
-                            List<Problem> connectivityProblems) {
-    super(featureProblems, connectivityProblems);
-    this.tables = Collections.unmodifiableList(new ArrayList<>(tables));
+  public Assessment(List<Problem> features, List<Problem> connectivity) {
+    this.features = Collections.unmodifiableList(new ArrayList<>(features));
+    this.connectivity = Collections.unmodifiableList(new ArrayList<>(connectivity));
   }
 
   /**
-   * @return summary of issues related to tables
+   * @return potential problems related to features
    */
-  public List<TableSummaryAssessment> getTables() {
-    return tables;
+  public List<Problem> getFeatures() {
+    return features;
+  }
+
+  /**
+   * @return potential problems related to connectivity
+   */
+  public List<Problem> getConnectivity() {
+    return connectivity;
   }
 
   @Override
@@ -49,15 +55,14 @@ public class PipelineAssessment extends Assessment {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    if (!super.equals(o)) {
-      return false;
-    }
-    PipelineAssessment that = (PipelineAssessment) o;
-    return Objects.equals(tables, that.tables);
+
+    Assessment that = (Assessment) o;
+    return Objects.equals(features, that.features) &&
+      Objects.equals(connectivity, that.connectivity);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), tables);
+    return Objects.hash(features, connectivity);
   }
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/assessment/TableAssessor.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/assessment/TableAssessor.java
@@ -16,6 +16,8 @@
 
 package io.cdap.delta.api.assessment;
 
+import java.util.Collections;
+
 /**
  * Creates assessments, highlighting potential problems. This is used when a pipeline is being created to give
  * users early feedback on configuration or environmental issues.
@@ -31,4 +33,14 @@ public interface TableAssessor<T> {
    * @return assessment of potential problems
    */
   TableAssessment assess(T tableDescriptor);
+
+  /**
+   * Assess whether there will be any general potential problems replicating data based unrelated to a specific table.
+   * For example, if there are problems connecting to the source/target system.
+   *
+   * @return an assessment of potential problems
+   */
+  default Assessment assess() {
+    return new Assessment(Collections.emptyList(), Collections.emptyList());
+  }
 }

--- a/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/DraftService.java
@@ -24,6 +24,7 @@ import io.cdap.delta.api.Configurer;
 import io.cdap.delta.api.DeltaSource;
 import io.cdap.delta.api.SourceColumn;
 import io.cdap.delta.api.SourceTable;
+import io.cdap.delta.api.assessment.Assessment;
 import io.cdap.delta.api.assessment.ColumnAssessment;
 import io.cdap.delta.api.assessment.ColumnDetail;
 import io.cdap.delta.api.assessment.ColumnSuggestion;
@@ -242,6 +243,13 @@ public class DraftService {
     List<Problem> missingFeatures = new ArrayList<>();
     List<Problem> connectivityIssues = new ArrayList<>();
     List<TableSummaryAssessment> tableAssessments = new ArrayList<>();
+
+    Assessment sourceAssessment = sourceTableAssessor.assess();
+    Assessment targetAssessment = targetTableAssessor.assess();
+    missingFeatures.addAll(sourceAssessment.getFeatures());
+    missingFeatures.addAll(targetAssessment.getFeatures());
+    connectivityIssues.addAll(sourceAssessment.getConnectivity());
+    connectivityIssues.addAll(targetAssessment.getConnectivity());
 
     // if no source tables are given, this means all tables should be read
     List<SourceTable> tablesToAssess = deltaConfig.getTables();


### PR DESCRIPTION
Sometimes plugins need to raise potential issues that are not
related to specific tables. For example, the BQ target needs to
raise a problem if it would generate too many load jobs per day.
Enhanced the assessor API to allow this.