### PR TITLE
CDAP-16737 protect against bad event readers

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/EventEmitter.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/EventEmitter.java
@@ -28,14 +28,18 @@ public interface EventEmitter {
    * This call may block if the pipeline target is not keeping up with the source.
    *
    * @param event the DDL event
+   * @throws InterruptedException if it was interrupted while blocked on emitting the event.
+   *   The event is dropped in this scenario.
    */
-  void emit(DDLEvent event);
+  void emit(DDLEvent event) throws InterruptedException;
 
   /**
    * Emits a DML event within its own transaction.
    * This call may block if the pipeline target is not keeping up with the source.
    *
    * @param event the DML event
+   * @throws InterruptedException if it was interrupted while blocked on emitting the event.
+   *   The event is dropped in this scenario.
    */
-  void emit(DMLEvent event);
+  void emit(DMLEvent event) throws InterruptedException;
 }

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
@@ -66,7 +67,7 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
     this.eventMetrics = eventMetrics;
     this.stateService = stateService;
     this.maxRetrySeconds = maxRetrySeconds;
-    this.runtimeArguments = runtimeArguments;
+    this.runtimeArguments = Collections.unmodifiableMap(new HashMap<>(runtimeArguments));
     this.failure = new AtomicReference<>(null);
   }
 

--- a/delta-app/src/test/java/io/cdap/delta/app/QueueingEventEmitterTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/QueueingEventEmitterTest.java
@@ -58,7 +58,7 @@ public class QueueingEventEmitterTest {
     .build();
 
   @Test
-  public void testEmit() {
+  public void testEmit() throws Exception {
     BlockingQueue<Sequenced<? extends ChangeEvent>> queue = new ArrayBlockingQueue<>(2);
     EventReaderDefinition readerDefinition = new EventReaderDefinition(Collections.emptySet(), Collections.emptySet(),
                                                                        Collections.emptySet());
@@ -71,7 +71,7 @@ public class QueueingEventEmitterTest {
   }
 
   @Test
-  public void testFiltering() {
+  public void testFiltering() throws Exception {
     BlockingQueue<Sequenced<? extends ChangeEvent>> queue = new ArrayBlockingQueue<>(2);
     Set<SourceTable> tables = Collections.singleton(
       new SourceTable("deebee", "taybull", null, Collections.emptySet(),


### PR DESCRIPTION
Changed the failure retry logic so that a new event queue is
used instead of re-using the existing queue. This is to protect
against bad event readers that are not really stopped after they
return from the stop() call. This prevents those types of
readers from adding events to the queue that shouldn't be there,
breaking the event ordering guarantee.

Also added some logging when readers and consumers are starting
and stopping so that the lifecycle of everything is more clear.

Also made the EventEmitter throw InterruptedException, since the
caller really does need to know when it is interrupted in
order to handle it properly and ensure everything shuts down.