### PR TITLE
fix pom file to include project url and scm info

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
   <name>Delta Pipelines</name>
   <packaging>pom</packaging>
   <description>CDAP Delta pipelines</description>
+  <url>https://github.com/data-integrations/delta</url>
 
   <licenses>
     <license>
@@ -41,6 +42,13 @@
       <organizationUrl>http://cdap.io</organizationUrl>
     </developer>
   </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/data-integrations/delta.git</connection>
+    <developerConnection>scm:git:git@github.com:data-integrations/delta.git</developerConnection>
+    <url>https://github.com/data-integrations/delta.git</url>
+    <tag>HEAD</tag>
+  </scm>
 
   <issueManagement>
     <url>https://issues.cask.co/browse/CDAP</url>


### PR DESCRIPTION
Need to add the Project URL and SCM info, because nexus artifact release fails without these