### PR TITLE
CDAP-17451 expose replicated tables in DeltaContext and add DeltaSource.initialize method

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaRuntimeContext.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaRuntimeContext.java
@@ -82,7 +82,7 @@ public interface DeltaRuntimeContext extends PluginContext {
   DeltaPipelineId getPipelineId();
 
   /**
-   * @return all the Tables to be replicated
+   * @return  all the tables to be replicated by the current pipeline
    */
-  Set<SourceTable> getTables();
+  Set<SourceTable> getAllTables();
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaRuntimeContext.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaRuntimeContext.java
@@ -21,6 +21,7 @@ import io.cdap.cdap.api.plugin.PluginContext;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -79,4 +80,9 @@ public interface DeltaRuntimeContext extends PluginContext {
    * @return the id of the delta pipeline
    */
   DeltaPipelineId getPipelineId();
+
+  /**
+   * @return all the Tables to be replicated
+   */
+  Set<SourceTable> getTables();
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
@@ -20,8 +20,6 @@ import io.cdap.delta.api.assessment.TableAssessorSupplier;
 import io.cdap.delta.api.assessment.TableDetail;
 import io.cdap.delta.api.assessment.TableRegistry;
 
-import java.util.List;
-
 /**
  * Pluggable interface for reading change events
  */
@@ -34,6 +32,16 @@ public interface DeltaSource extends TableAssessorSupplier<TableDetail> {
    * @param configurer source configurer used to set configuration settings and register plugins
    */
   void configure(SourceConfigurer configurer);
+
+  /**
+   * Initialize the Delta Source stage. This is called after the application is deployed, whenever
+   * the program is initialized.
+   *
+   * @param context {@link DeltaSourceContext}
+   * @throws Exception if there is any error during initialization
+   */
+  default void initailize(DeltaSourceContext context) throws Exception {
+  }
 
   /**
    * Create an event reader used to read change events. This is called after the application is deployed, whenever

--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaSource.java
@@ -40,7 +40,7 @@ public interface DeltaSource extends TableAssessorSupplier<TableDetail> {
    * @param context {@link DeltaSourceContext}
    * @throws Exception if there is any error during initialization
    */
-  default void initailize(DeltaSourceContext context) throws Exception {
+  default void initialize(DeltaSourceContext context) throws Exception {
   }
 
   /**

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
@@ -190,7 +190,7 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
   }
 
   @Override
-  public Set<SourceTable> getTables() {
+  public Set<SourceTable> getAllTables() {
     return tables;
   }
 

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
@@ -30,6 +30,7 @@ import io.cdap.delta.api.DeltaTargetContext;
 import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.ReplicationError;
 import io.cdap.delta.api.SourceProperties;
+import io.cdap.delta.api.SourceTable;
 import io.cdap.delta.proto.DBTable;
 import io.cdap.delta.store.StateStore;
 import org.slf4j.Logger;
@@ -38,7 +39,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 
@@ -60,11 +64,12 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
   private final Map<String, String> runtimeArguments;
   private final AtomicReference<Throwable> failure;
   private final SourceProperties sourceProperties;
+  private final Set<SourceTable> tables;
 
   DeltaContext(DeltaWorkerId id, String runId, Metrics metrics, StateStore stateStore,
                PluginContext pluginContext, PipelineStateService stateService,
                int maxRetrySeconds, Map<String, String> runtimeArguments,
-               @Nullable SourceProperties sourceProperties) {
+               @Nullable SourceProperties sourceProperties, List<SourceTable> tables) {
     this.id = id;
     this.runId = runId;
     this.metrics = metrics;
@@ -76,6 +81,7 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
     this.runtimeArguments = Collections.unmodifiableMap(new HashMap<>(runtimeArguments));
     this.failure = new AtomicReference<>(null);
     this.sourceProperties = sourceProperties;
+    this.tables = Collections.unmodifiableSet(new HashSet<>(tables));
   }
 
   @Override
@@ -181,6 +187,11 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
   @Override
   public DeltaPipelineId getPipelineId() {
     return id.getPipelineId();
+  }
+
+  @Override
+  public Set<SourceTable> getTables() {
+    return tables;
   }
 
   @Override

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
@@ -180,7 +180,7 @@ public class DeltaWorker extends AbstractWorker {
     MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(context.getRuntimeArguments(),
                                                               context, context.getNamespace());
     source = context.newPluginInstance(sourceName, macroEvaluator);
-    source.initailize(deltaContext);
+    source.initialize(deltaContext);
     target = context.newPluginInstance(targetName, macroEvaluator);
     OffsetAndSequence offsetAndSequence = deltaContext.loadOffset();
     offset = offsetAndSequence.getOffset();

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
@@ -176,10 +176,11 @@ public class DeltaWorker extends AbstractWorker {
     stateService.load();
     deltaContext = new DeltaContext(id, context.getRunId().getId(), metrics, stateStore, context,
                                     stateService, config.getRetryConfig().getMaxDurationSeconds(),
-                                    context.getRuntimeArguments(), sourceProperties);
+                                    context.getRuntimeArguments(), sourceProperties, config.getTables());
     MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(context.getRuntimeArguments(),
                                                               context, context.getNamespace());
     source = context.newPluginInstance(sourceName, macroEvaluator);
+    source.initailize(deltaContext);
     target = context.newPluginInstance(targetName, macroEvaluator);
     OffsetAndSequence offsetAndSequence = deltaContext.loadOffset();
     offset = offsetAndSequence.getOffset();


### PR DESCRIPTION
Some delta source need to know what are all the tables to be replicated so that it can initialize some resources based on the tables.