### PR TITLE
CDAP-17371 Emit metric for error as soon as it is received from target.

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
@@ -119,7 +119,7 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
   public void setTableError(String database, @Nullable String schema, String table,
                             ReplicationError error) throws IOException {
     stateService.setTableError(new DBTable(database, schema, table), error);
-    getEventMetricsForTable(database, schema, table).incrementDMLErrorCount();
+    getEventMetricsForTable(database, schema, table).emitDMLErrorMetric();
   }
 
   private EventMetrics getEventMetricsForTable(String database, String schema, String table) {

--- a/delta-app/src/main/java/io/cdap/delta/app/EventMetrics.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/EventMetrics.java
@@ -28,7 +28,6 @@ import java.util.Map;
 public class EventMetrics {
   private final Metrics metrics;
   private final Map<DMLOperation.Type, Integer> dmlEventCounts;
-  private int dmlErrorCount;
   private int ddlEventCount;
   private long oldestTimeStampInMillis;
   private int bytesProcessed;
@@ -53,8 +52,8 @@ public class EventMetrics {
     ddlEventCount++;
   }
 
-  public synchronized void incrementDMLErrorCount() {
-    dmlErrorCount++;
+  public synchronized void emitDMLErrorMetric() {
+    metrics.count("dml.errors", 1);
   }
 
   public synchronized void emitMetrics() {
@@ -63,7 +62,6 @@ public class EventMetrics {
     }
 
     metrics.count("dml.data.processed.bytes", bytesProcessed);
-    metrics.count("dml.errors", dmlErrorCount);
     metrics.gauge("dml.latency.seconds", oldestTimeStampInMillis == 0L ? 0
       : (System.currentTimeMillis() - oldestTimeStampInMillis) / 1000);
     metrics.count("ddl", ddlEventCount);
@@ -72,7 +70,6 @@ public class EventMetrics {
 
   public synchronized void clear() {
     bytesProcessed = 0;
-    dmlErrorCount = 0;
     ddlEventCount = 0;
     oldestTimeStampInMillis = 0;
     for (DMLOperation.Type op : DMLOperation.Type.values()) {

--- a/delta-test/src/main/java/io/cdap/delta/test/DeltaPipelineTestBase.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/DeltaPipelineTestBase.java
@@ -23,6 +23,7 @@ import io.cdap.cdap.test.TestBase;
 import io.cdap.delta.api.ChangeEvent;
 import io.cdap.delta.api.assessment.TableDetail;
 import io.cdap.delta.test.mock.FailureTarget;
+import io.cdap.delta.test.mock.MockErrorTarget;
 import io.cdap.delta.test.mock.MockSource;
 import io.cdap.delta.test.mock.MockTarget;
 
@@ -55,8 +56,9 @@ public class DeltaPipelineTestBase extends TestBase {
     Set<PluginClass> pluginClasses = new HashSet<>();
     pluginClasses.add(MockSource.PLUGIN_CLASS);
     pluginClasses.add(MockTarget.PLUGIN_CLASS);
+    pluginClasses.add(MockErrorTarget.PLUGIN_CLASS);
     pluginClasses.add(FailureTarget.PLUGIN_CLASS);
     addPluginArtifact(mocksArtifactId, ARTIFACT_ID, pluginClasses,
-                      MockSource.class, MockTarget.class, FailureTarget.class);
+                      MockSource.class, MockTarget.class, MockErrorTarget.class, FailureTarget.class);
   }
 }

--- a/delta-test/src/main/java/io/cdap/delta/test/mock/MockErrorTarget.java
+++ b/delta-test/src/main/java/io/cdap/delta/test/mock/MockErrorTarget.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.test.mock;
+
+import io.cdap.cdap.api.annotation.Name;
+import io.cdap.cdap.api.plugin.PluginClass;
+import io.cdap.cdap.api.plugin.PluginConfig;
+import io.cdap.delta.api.Configurer;
+import io.cdap.delta.api.DDLEvent;
+import io.cdap.delta.api.DMLEvent;
+import io.cdap.delta.api.DMLOperation;
+import io.cdap.delta.api.DeltaSource;
+import io.cdap.delta.api.DeltaTarget;
+import io.cdap.delta.api.DeltaTargetContext;
+import io.cdap.delta.api.EventConsumer;
+import io.cdap.delta.api.ReplicationError;
+import io.cdap.delta.api.Sequenced;
+import io.cdap.delta.api.assessment.StandardizedTableDetail;
+import io.cdap.delta.api.assessment.TableAssessment;
+import io.cdap.delta.api.assessment.TableAssessor;
+import io.cdap.delta.proto.Artifact;
+import io.cdap.delta.proto.Plugin;
+
+import java.util.Collections;
+import java.util.HashMap;
+
+/**
+ * Mock target used in unit tests. It only sets errors to context.
+ */
+@io.cdap.cdap.api.annotation.Plugin(type = DeltaTarget.PLUGIN_TYPE)
+@Name(MockErrorTarget.NAME)
+public class MockErrorTarget implements DeltaTarget {
+  static final String NAME = "mockerror";
+
+  public static final PluginClass PLUGIN_CLASS = getPluginClass();
+  private final Conf conf;
+
+  public MockErrorTarget(Conf conf) {
+    this.conf = conf;
+  }
+
+  /**
+   * Config for the plugin
+   */
+  private static class Conf extends PluginConfig {
+  }
+
+  @Override
+  public void configure(Configurer configurer) {
+    // no-op
+  }
+
+  @Override
+  public EventConsumer createConsumer(DeltaTargetContext context) throws Exception {
+    return new EventConsumer() {
+      @Override
+      public void start() {
+
+      }
+
+      @Override
+      public void applyDDL(Sequenced<DDLEvent> event) throws Exception {
+
+      }
+
+      @Override
+      public void applyDML(Sequenced<DMLEvent> event) throws Exception {
+        DMLOperation operation = event.getEvent().getOperation();
+        context.setTableError(operation.getDatabaseName(), operation.getTableName(),
+                              new ReplicationError(new Exception()));
+      }
+    };
+  }
+
+  public static Plugin getPlugin() {
+    return new Plugin(NAME, DeltaTarget.PLUGIN_TYPE, new HashMap<>(), Artifact.EMPTY);
+  }
+
+  @Override
+  public TableAssessor<StandardizedTableDetail> createTableAssessor(Configurer configurer) throws Exception {
+    return tableDetail -> new TableAssessment(Collections.emptyList(), Collections.emptyList());
+  }
+
+  private static PluginClass getPluginClass() {
+    return new PluginClass(DeltaTarget.PLUGIN_TYPE, NAME, "", MockErrorTarget.class.getName(), "conf",
+                           new HashMap<>());
+  }
+}


### PR DESCRIPTION
Currently we emit all metrics once offset is committed by target in the replicator app. However it is possible in some cases that pipeline keep generating errors. In those cases error metic will not be published since commit offset will never get called. Ideally error should be emitted as soon as its received from target since its independent on committing offset.