### PR TITLE
don't remove '\' when evaluate Macro

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentHandler.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/service/AssessmentHandler.java
@@ -20,8 +20,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonSyntaxException;
 import io.cdap.cdap.api.NamespaceSummary;
-import io.cdap.cdap.api.macro.MacroEvaluator;
-import io.cdap.cdap.api.macro.MacroParserOptions;
 import io.cdap.cdap.api.plugin.PluginConfigurer;
 import io.cdap.cdap.api.service.http.AbstractSystemHttpServiceHandler;
 import io.cdap.cdap.api.service.http.HttpServiceRequest;
@@ -44,13 +42,12 @@ import io.cdap.delta.proto.PipelineState;
 import io.cdap.delta.proto.StateRequest;
 import io.cdap.delta.proto.TableAssessmentResponse;
 import io.cdap.delta.proto.TableReplicationState;
-import io.cdap.delta.store.DefaultMacroEvaluator;
 import io.cdap.delta.store.Draft;
 import io.cdap.delta.store.DraftId;
 import io.cdap.delta.store.DraftService;
 import io.cdap.delta.store.Namespace;
-import io.cdap.delta.store.PropertyEvaluator;
 import io.cdap.delta.store.StateStore;
+import io.cdap.delta.store.SystemServicePropertyEvaluator;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -60,7 +57,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
@@ -313,15 +309,7 @@ public class AssessmentHandler extends AbstractSystemHttpServiceHandler {
     }
 
     try {
-      endpoint.respond(new DraftService(context, new PropertyEvaluator() {
-        @Override
-        public Map<String, String> evaluate(String namespace, Map<String, String> properties) {
-          MacroEvaluator macroEvaluator = new DefaultMacroEvaluator(context.getRuntimeArguments(), context, namespace);
-          return context.evaluateMacros(namespace, properties, macroEvaluator,
-            MacroParserOptions.builder().disableLookups()
-              .setFunctionWhitelist(DefaultMacroEvaluator.SECURE_FUNCTION_NAME).setEscaping(false).build());
-        }
-      }), namespace);
+      endpoint.respond(new DraftService(context, new SystemServicePropertyEvaluator(context)), namespace);
     } catch (CodedException e) {
       responder.sendError(e.getCode(), e.getMessage());
     } catch (TableNotFoundException e) {

--- a/delta-app/src/main/java/io/cdap/delta/store/SystemServicePropertyEvaluator.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/SystemServicePropertyEvaluator.java
@@ -30,6 +30,7 @@ public class SystemServicePropertyEvaluator implements PropertyEvaluator {
   private static final MacroParserOptions OPTIONS = MacroParserOptions.builder()
     .disableLookups()
     .setFunctionWhitelist(DefaultMacroEvaluator.SECURE_FUNCTION_NAME)
+    .setEscaping(false)
     .build();
   private final SystemHttpServiceContext context;
 


### PR DESCRIPTION
what's wrong :

'\' is removed when evaluate macro in service account key, because we enabled the "escape" and below code will remove the '\' :
https://github.com/cdapio/cdap/blob/7dade6fc7376945673913714dea9bbbe79aff2f6/cdap-app-fabric/src/main/java/io/cdap/cdap/internal/app/runtime/plugin/MacroParser.java#L244

solution:
should disable "escape" for delta , it's not correct for service account keys