### PR TITLE
[Cherry-Pick]don't remove '\' when evaluate Macro (#117)

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/store/SystemServicePropertyEvaluator.java
+++ b/delta-app/src/main/java/io/cdap/delta/store/SystemServicePropertyEvaluator.java
@@ -30,6 +30,7 @@ public class SystemServicePropertyEvaluator implements PropertyEvaluator {
   private static final MacroParserOptions OPTIONS = MacroParserOptions.builder()
     .disableLookups()
     .setFunctionWhitelist(DefaultMacroEvaluator.SECURE_FUNCTION_NAME)
+    .setEscaping(false)
     .build();
   private final SystemHttpServiceContext context;
 


### PR DESCRIPTION
cherry-pick of https://github.com/data-integrations/delta/pull/118