### PR TITLE
resolve the event queue stucking issue

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DMLEvent.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DMLEvent.java
@@ -84,6 +84,10 @@ public class DMLEvent extends ChangeEvent {
     if (sizeInBytes < 0) {
       // the size of all other fields are fixed, only return the dynamic size of row and previousRow
       sizeInBytes = operation.getSizeInBytes() + computeSizeInBytes(previousRow);
+      // delete event didn't count the size of row in the DMLOperation
+      if (operation.getType() == DMLOperation.Type.DELETE) {
+        sizeInBytes += computeSizeInBytes(row);
+      }
     }
     return sizeInBytes;
   }


### PR DESCRIPTION
we have two limit of the queue, one is the capacity indicating the total bytes of the events in the queue and the other is the queue size indicating the total number of the events in the queue

the root cause of the issue is the line below 
https://github.com/data-integrations/delta/blob/ecd63ebb373651e1fabc02ac6081d61cb6b59f08/delta-app/src/main/java/io/cdap/delta/app/CapacityBoundedEventQueue.java#L75

initially `notFull` condition was only used to indicate the condition that when the capacity is reached. While above line can happen also when the # of events are reached limit. 

While the corresponding notify method like below :
https://github.com/data-integrations/delta/blob/ecd63ebb373651e1fabc02ac6081d61cb6b59f08/delta-app/src/main/java/io/cdap/delta/app/CapacityBoundedEventQueue.java#L130
is guarded by `if (eventSize > 0)`, thus if the event queue is filled with all those events that have size 0, when it's full, the producer thread will stuck forever, because the consumer thread will not notify the producer after it's consuming event from the queue.

and this will happen for delete events which we calculate their size as 0 (for metrics).

so the fix is to correctly calculate the size of delete event size and since we will never have 0 size event, we can use `notFull` to indicate the condition when either capacity or # of events reaches the limit.