### PR TITLE
CDAP-17586 don't assign sequence number to DDL event

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/Sequenced.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/Sequenced.java
@@ -26,18 +26,26 @@ import java.util.Objects;
 public class Sequenced<T> {
   private final T event;
   private final long sequenceNumber;
+  private static final long UNSUPPORTED_SEQUENCE = -1;
 
+  public Sequenced(T event) {
+    this(event, UNSUPPORTED_SEQUENCE);
+  }
   public Sequenced(T event, long sequenceNumber) {
     this.event = event;
     this.sequenceNumber = sequenceNumber;
   }
 
-  public T getEvent() {
-    return event;
+  public long getSequenceNumber() {
+    if (sequenceNumber == UNSUPPORTED_SEQUENCE) {
+      throw new UnsupportedOperationException();
+    }
+    return sequenceNumber;
   }
 
-  public long getSequenceNumber() {
-    return sequenceNumber;
+
+  public T getEvent() {
+    return event;
   }
 
   @Override
@@ -57,4 +65,5 @@ public class Sequenced<T> {
   public int hashCode() {
     return Objects.hash(event, sequenceNumber);
   }
+
 }

--- a/delta-api/src/main/java/io/cdap/delta/api/Sequenced.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/Sequenced.java
@@ -28,6 +28,11 @@ public class Sequenced<T> {
   private final long sequenceNumber;
   private static final long UNSUPPORTED_SEQUENCE = -1;
 
+  /**
+   * Those events that don't support sequence number should use this constructor.
+   * e.g. DDL event
+   * @param event the event
+   */
   public Sequenced(T event) {
     this(event, UNSUPPORTED_SEQUENCE);
   }
@@ -36,9 +41,13 @@ public class Sequenced<T> {
     this.sequenceNumber = sequenceNumber;
   }
 
+  /**
+   * If the event doesn't support sequence number, an UnsupportedOperationException will be thrown.
+   * @return the sequence number of the event
+   */
   public long getSequenceNumber() {
     if (sequenceNumber == UNSUPPORTED_SEQUENCE) {
-      throw new UnsupportedOperationException();
+      throw new UnsupportedOperationException("This event does not support sequence number.");
     }
     return sequenceNumber;
   }

--- a/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
@@ -65,7 +65,7 @@ public class QueueingEventEmitter implements EventEmitter {
 
     try {
       // don't assign sequence number to DDL event
-      eventQueue.put(new Sequenced<>(event, -1));
+      eventQueue.put(new Sequenced<>(event));
     } catch (InterruptedException e) {
       // this should only happen when the event consumer is stopped
       // in that case, don't emit any more events

--- a/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/QueueingEventEmitter.java
@@ -64,7 +64,8 @@ public class QueueingEventEmitter implements EventEmitter {
     }
 
     try {
-      eventQueue.put(new Sequenced<>(event, ++sequenceNumber));
+      // don't assign sequence number to DDL event
+      eventQueue.put(new Sequenced<>(event, -1));
     } catch (InterruptedException e) {
       // this should only happen when the event consumer is stopped
       // in that case, don't emit any more events

--- a/delta-app/src/test/java/io/cdap/delta/app/DeltaPipelineTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/DeltaPipelineTest.java
@@ -170,7 +170,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
     stateService.load();
 
     OffsetAndSequence offsetAndSequence = stateStore.readOffset(workerId);
-    Assert.assertEquals(2L, offsetAndSequence.getSequenceNumber());
+    Assert.assertEquals(1L, offsetAndSequence.getSequenceNumber());
 
     TableReplicationState tableState = new TableReplicationState(DATABASE, TABLE, TableState.REPLICATING, null);
     PipelineReplicationState expectedState = new PipelineReplicationState(PipelineState.OK,
@@ -217,7 +217,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
     stateService.load();
 
     OffsetAndSequence offsetAndSequence = stateStore.readOffset(workerId);
-    Assert.assertEquals(1L, offsetAndSequence.getSequenceNumber());
+    Assert.assertEquals(0L, offsetAndSequence.getSequenceNumber());
 
     // should only have written out the first change
     List<? extends ChangeEvent> actual = FileEventConsumer.readEvents(outputFolder, 0);
@@ -234,7 +234,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
     manager.waitForStopped(60, TimeUnit.SECONDS);
 
     offsetAndSequence = stateStore.readOffset(workerId);
-    Assert.assertEquals(2L, offsetAndSequence.getSequenceNumber());
+    Assert.assertEquals(1L, offsetAndSequence.getSequenceNumber());
 
     // second change should have been written
     actual = FileEventConsumer.readEvents(outputFolder, 0);
@@ -253,7 +253,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
 
     // configure the target to throw exceptions after the first event is applied
     // until the proceedFile is created
-    Stage target = new Stage("target", FailureTarget.failImmediately(1L));
+    Stage target = new Stage("target", FailureTarget.failImmediately(0L));
     DeltaConfig config = DeltaConfig.builder()
       .setSource(source)
       .setTarget(target)
@@ -335,7 +335,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
 
     // configure the target to throw exceptions after the first event is applied
     // until the proceedFile is created
-    Stage target = new Stage("target", FailureTarget.failAfter(1L, targetProceedFile));
+    Stage target = new Stage("target", FailureTarget.failAfter(0L, targetProceedFile));
     DeltaConfig config = DeltaConfig.builder()
       .setSource(source)
       .setTarget(target)
@@ -406,7 +406,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
 
     // verify that the sequence number was correctly being rolled back during errors and not incremented
     OffsetAndSequence offsetAndSequence = stateStore.readOffset(workerId);
-    Assert.assertEquals(2L, offsetAndSequence.getSequenceNumber());
+    Assert.assertEquals(1L, offsetAndSequence.getSequenceNumber());
 
     // verify that metrics were not double counted during errors
     waitForMetric(appId, "ddl", 1);
@@ -480,7 +480,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
     stateService.load();
 
     OffsetAndSequence offsetAndSequence = stateStore.readOffset(workerId);
-    Assert.assertEquals(2L, offsetAndSequence.getSequenceNumber());
+    Assert.assertEquals(1L, offsetAndSequence.getSequenceNumber());
 
     TableReplicationState tableState = new TableReplicationState(DATABASE, TABLE, TableState.REPLICATING, null);
     PipelineReplicationState expectedState = new PipelineReplicationState(PipelineState.OK,
@@ -494,7 +494,7 @@ public class DeltaPipelineTest extends DeltaPipelineTestBase {
     stateService.load();
 
     offsetAndSequence = stateStore.readOffset(workerId);
-    Assert.assertEquals(1L, offsetAndSequence.getSequenceNumber());
+    Assert.assertEquals(0L, offsetAndSequence.getSequenceNumber());
 
     tableState = new TableReplicationState(DATABASE, TABLE2, TableState.REPLICATING, null);
     expectedState = new PipelineReplicationState(PipelineState.OK, Collections.singleton(tableState), null);

--- a/delta-app/src/test/java/io/cdap/delta/app/QueueingEventEmitterTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/QueueingEventEmitterTest.java
@@ -66,8 +66,8 @@ public class QueueingEventEmitterTest {
     emitter.emit(DDL);
     emitter.emit(DML);
 
-    Assert.assertEquals(new Sequenced<>(DDL, 1L), queue.poll());
-    Assert.assertEquals(new Sequenced<>(DML, 2L), queue.poll());
+    Assert.assertEquals(new Sequenced<>(DDL), queue.poll());
+    Assert.assertEquals(new Sequenced<>(DML, 1L), queue.poll());
   }
 
   @Test


### PR DESCRIPTION
sequence number is used to record the latest DML event applied in the target database. assigning sequence number to DDL event will cause some problem in some cases , see https://cdap.atlassian.net/jira/software/c/projects/CDAP/issues/CDAP-17586 for details.