### PR TITLE
Throw DeltaFailureRuntimeException when pipeline is run without prima…(CDAP-19607) 

### DIFF
--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaFailureRuntimeException.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaFailureRuntimeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2020 Cask Data, Inc.
+ * Copyright © 2022 Cask Data, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/delta-api/src/main/java/io/cdap/delta/api/DeltaFailureRuntimeException.java
+++ b/delta-api/src/main/java/io/cdap/delta/api/DeltaFailureRuntimeException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright © 2020 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.api;
+
+/**
+ * Thrown when an error is encountered that cannot be recovered from, which should result in the pipeline to fail
+ * without retrying anything.
+ */
+public class DeltaFailureRuntimeException extends RuntimeException {
+
+  public DeltaFailureRuntimeException(String message) {
+    super(message);
+  }
+
+  public DeltaFailureRuntimeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/delta-app/pom.xml
+++ b/delta-app/pom.xml
@@ -32,6 +32,7 @@
 
   <properties>
     <app.main.class>io.cdap.delta.app.DeltaApp</app.main.class>
+    <powermock.version>2.0.9</powermock.version>
   </properties>
 
   <dependencies>
@@ -90,6 +91,18 @@
       <groupId>net.jodah</groupId>
       <artifactId>failsafe</artifactId>
       <version>${failsafe.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>${powermock.version}</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaWorker.java
@@ -36,6 +36,7 @@ import io.cdap.delta.api.DDLOperation;
 import io.cdap.delta.api.DMLEvent;
 import io.cdap.delta.api.DMLOperation;
 import io.cdap.delta.api.DeltaFailureException;
+import io.cdap.delta.api.DeltaFailureRuntimeException;
 import io.cdap.delta.api.DeltaPipelineId;
 import io.cdap.delta.api.DeltaSource;
 import io.cdap.delta.api.DeltaTarget;
@@ -318,8 +319,8 @@ public class DeltaWorker extends AbstractWorker {
         .onFailedAttempt(failureContext -> {
           Throwable failure = failureContext.getLastFailure();
           error.set(failure);
-          if (failure instanceof DeltaFailureException) {
-            LOG.warn("Encountered an error that cannot be retried. Failing the pipeline...", failure);
+          if (failure instanceof DeltaFailureException || failure instanceof DeltaFailureRuntimeException) {
+            LOG.error("Encountered an error that cannot be retried. Failing the pipeline...", failure);
             shouldStop.set(true);
           }
 

--- a/delta-app/src/test/java/io/cdap/delta/app/DeltaWorkerTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/DeltaWorkerTest.java
@@ -16,8 +16,21 @@
 
 package io.cdap.delta.app;
 
+import io.cdap.cdap.api.app.ApplicationSpecification;
+import io.cdap.cdap.api.data.schema.Schema;
+import io.cdap.cdap.api.worker.WorkerConfigurer;
+import io.cdap.cdap.api.worker.WorkerContext;
+import io.cdap.cdap.api.worker.WorkerSpecification;
+import io.cdap.cdap.app.DefaultAppConfigurer;
+import io.cdap.cdap.internal.app.DefaultApplicationSpecification;
+import io.cdap.delta.api.DDLEvent;
+import io.cdap.delta.api.DDLOperation;
+import io.cdap.delta.api.DeltaFailureRuntimeException;
 import io.cdap.delta.api.DeltaSource;
 import io.cdap.delta.api.DeltaTarget;
+import io.cdap.delta.api.EventConsumer;
+import io.cdap.delta.api.EventReader;
+import io.cdap.delta.api.Offset;
 import io.cdap.delta.api.SourceTable;
 import io.cdap.delta.proto.Artifact;
 import io.cdap.delta.proto.DeltaConfig;
@@ -26,20 +39,43 @@ import io.cdap.delta.proto.ParallelismConfig;
 import io.cdap.delta.proto.Plugin;
 import io.cdap.delta.proto.Stage;
 import io.cdap.delta.proto.TableId;
+import io.cdap.delta.store.RemoteStateStore;
+import io.cdap.delta.store.StateStoreMigrator;
+import io.cdap.delta.test.mock.MockSource;
+import io.cdap.delta.test.mock.MockTarget;
+import org.apache.twill.api.RunId;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
 
+import static org.mockito.Mockito.*;
+
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Tests for {@link DeltaWorker}.
  */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({WorkerSpecification.class, DefaultApplicationSpecification.class, DeltaWorker.class})
+
 public class DeltaWorkerTest {
+  @Rule
+  final ExpectedException exception = ExpectedException.none();
   private static final SourceTable TABLE1 = new SourceTable("db", "t1");
   private static final SourceTable TABLE2 = new SourceTable("db", "t2");
   private static final SourceTable TABLE3 = new SourceTable("db", "t3");
@@ -100,5 +136,65 @@ public class DeltaWorkerTest {
     expected.put(1, instance1Tables);
     Map<Integer, Set<TableId>> assignments = DeltaWorker.assignTables(config);
     Assert.assertEquals(expected, assignments);
+  }
+
+  @Test
+  public void testDeltaFailureRuntimeException() throws Exception {
+    //Define DeltaConfig which is used as param in DeltaWorker constructor
+    String DATABASE = "testreplication";
+    String TABLE = "npe";
+    Schema SCHEMA = Schema.recordOf(TABLE, Schema.Field.of("id", Schema.of(Schema.Type.INT)));
+    DDLEvent EVENT1 = DDLEvent.builder().setOffset(new Offset(Collections.singletonMap("order", "0"))).setOperation(DDLOperation.Type.CREATE_TABLE).setDatabaseName(DATABASE).setTableName(TABLE).setPrimaryKey(Collections.singletonList("id")).setSchema(SCHEMA).build();
+    Stage source = new Stage("src", MockSource.getPlugin(Arrays.asList(EVENT1)));
+    Stage target = new Stage("target", MockTarget.getPlugin(new File("./")));
+    DeltaConfig config = DeltaConfig.builder().setSource(source).setTarget(target).setOffsetBasePath(null).build();
+
+    //Mock worker context,application specification,event reader and event consumer for initialize method
+    WorkerContext workerContext = mock(WorkerContext.class);
+    when(workerContext.getNamespace()).thenReturn("default");
+    when(workerContext.getInstanceId()).thenReturn(0);
+    when(workerContext.getRunId()).thenReturn(mock(RunId.class));
+    DeltaSource deltaSource = mock(DeltaSource.class);
+    DeltaTarget deltaTarget = mock(DeltaTarget.class);
+    EventReader eventReader = mock(EventReader.class);
+    EventConsumer eventConsumer = mock(EventConsumer.class);
+    doNothing().when(eventReader).start(any());
+    doNothing().when(eventConsumer).start();
+    when(deltaSource.createReader(any(), any(), any())).thenReturn(eventReader);
+    when(deltaTarget.createConsumer(any())).thenReturn(eventConsumer);
+    when(workerContext.newPluginInstance(eq("Microsoft SQLServer"), any())).thenReturn(deltaSource);
+    when(workerContext.newPluginInstance(eq("BigQuery"), any())).thenReturn(deltaTarget);
+    ApplicationSpecification appSpec = PowerMockito.mock(DefaultApplicationSpecification.class);
+    when(appSpec.getName()).thenReturn("DeltaWorker");
+    when(workerContext.getApplicationSpecification()).thenReturn(appSpec);
+    when(appSpec.getConfiguration()).thenReturn(new String(Files.readAllBytes(Paths.get("./src/test/java/io/cdap/delta/app/appSpec-config.json"))));
+
+    WorkerSpecification spec = PowerMockito.mock(WorkerSpecification.class);
+    PowerMockito.when(workerContext.getSpecification()).thenReturn(spec);
+    PowerMockito.when(spec.getProperty("generation")).thenReturn("0");
+    PowerMockito.when(spec.getProperty("table.assignments")).thenReturn("{\"0\":[{\"database\":\"testreplication\",\"table\":\"npe\",\"schema\":\"dbo\"}]}");
+
+    RemoteStateStore remoteStateStore = PowerMockito.mock(RemoteStateStore.class);
+    PowerMockito.whenNew(RemoteStateStore.class).withArguments(workerContext).thenReturn(remoteStateStore);
+    when(remoteStateStore.readState(any(), any())).thenReturn(null);
+
+    StateStoreMigrator stateStoreMigrator = PowerMockito.mock(StateStoreMigrator.class);
+    PowerMockito.whenNew(StateStoreMigrator.class).withArguments(any(), any(), any()).thenReturn(stateStoreMigrator);
+    when(stateStoreMigrator.perform()).thenReturn(false);
+
+    //Throw Delta Failure runtime exception while polling event queue in run method
+    CapacityBoundedEventQueue eventQueue = mock(CapacityBoundedEventQueue.class);
+    PowerMockito.whenNew(CapacityBoundedEventQueue.class).withArguments(anyInt(), anyLong()).thenReturn(eventQueue);
+    doThrow(new DeltaFailureRuntimeException("")).when(eventQueue).poll(anyLong(), eq(TimeUnit.SECONDS));
+
+    DeltaWorker deltaWorker = new DeltaWorker(config, null, mock(DefaultAppConfigurer.class));
+    deltaWorker.configure(mock(WorkerConfigurer.class));
+    try {
+      deltaWorker.initialize(workerContext);
+    } catch (Exception e) {
+      throw e;
+    }
+    exception.expect(DeltaFailureRuntimeException.class);
+    deltaWorker.run();
   }
 }

--- a/delta-app/src/test/java/io/cdap/delta/app/appSpec-config.json
+++ b/delta-app/src/test/java/io/cdap/delta/app/appSpec-config.json
@@ -1,0 +1,68 @@
+{
+  "description": "",
+  "connections": [
+    {
+      "from": "Microsoft SQLServer",
+      "to": "BigQuery"
+    }
+  ],
+  "stages": [
+    {
+      "name": "Microsoft SQLServer",
+      "plugin": {
+        "name": "sqlserver",
+        "type": "cdcSource",
+        "artifact": {
+          "name": "sqlserver-delta-plugins",
+          "version": "0.8.0-SNAPSHOT",
+          "scope": "SYSTEM"
+        },
+        "properties": {
+          "port": "1433",
+          "serverTimezone": "UTC",
+          "replicateExistingData": "true",
+          "host": "34.82.29.3",
+          "jdbcPluginName": "sqlserver42",
+          "database": "testreplication",
+          "user": "rep_user",
+          "password": "test@123"
+        }
+      }
+    },
+    {
+      "name": "BigQuery",
+      "plugin": {
+        "name": "bigquery",
+        "type": "cdcTarget",
+        "artifact": {
+          "name": "bigquery-delta-plugins",
+          "version": "0.7.0-SNAPSHOT",
+          "scope": "SYSTEM"
+        },
+        "properties": {
+          "project": "auto-detect",
+          "serviceAccountKey": "auto-detect",
+          "stagingBucketLocation": "us",
+          "loadInterval": "90",
+          "stagingTablePrefix": "_staging_",
+          "requireManualDrops": "false",
+          "softDeletes": "false"
+        }
+      }
+    }
+  ],
+  "tables": [
+    {
+      "database": "testreplication",
+      "table": "npe",
+      "schema": "dbo"
+    }
+  ],
+  "offsetBasePath": "checkpoints/delta",
+  "parallelism": {
+    "numInstances": 1.0
+  },
+  "tableTransformations": [
+
+  ]
+}

--- a/delta-app/src/test/java/io/cdap/delta/app/appSpec-config.json
+++ b/delta-app/src/test/java/io/cdap/delta/app/appSpec-config.json
@@ -14,18 +14,8 @@
         "type": "cdcSource",
         "artifact": {
           "name": "sqlserver-delta-plugins",
-          "version": "0.8.0-SNAPSHOT",
+          "version": "",
           "scope": "SYSTEM"
-        },
-        "properties": {
-          "port": "1433",
-          "serverTimezone": "UTC",
-          "replicateExistingData": "true",
-          "host": "34.82.29.3",
-          "jdbcPluginName": "sqlserver42",
-          "database": "testreplication",
-          "user": "rep_user",
-          "password": "test@123"
         }
       }
     },
@@ -36,33 +26,10 @@
         "type": "cdcTarget",
         "artifact": {
           "name": "bigquery-delta-plugins",
-          "version": "0.7.0-SNAPSHOT",
+          "version": "",
           "scope": "SYSTEM"
-        },
-        "properties": {
-          "project": "auto-detect",
-          "serviceAccountKey": "auto-detect",
-          "stagingBucketLocation": "us",
-          "loadInterval": "90",
-          "stagingTablePrefix": "_staging_",
-          "requireManualDrops": "false",
-          "softDeletes": "false"
         }
       }
     }
-  ],
-  "tables": [
-    {
-      "database": "testreplication",
-      "table": "npe",
-      "schema": "dbo"
-    }
-  ],
-  "offsetBasePath": "checkpoints/delta",
-  "parallelism": {
-    "numInstances": 1.0
-  },
-  "tableTransformations": [
-
   ]
 }


### PR DESCRIPTION
…ry key in table.

- Added DeltaFailureRuntimeException.

-  Fail the pipeline throwing DeltaFailureRuntimeException, when it is run without primary key in a table.

Link to the JIRA bug: https://cdap.atlassian.net/browse/CDAP-19607.