### PR TITLE
[CDAP-20224] Remove Explore References from `delta`

### DIFF
--- a/delta-app/src/test/java/io/cdap/delta/app/DeltaPipelineStateStoreBaseTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/DeltaPipelineStateStoreBaseTest.java
@@ -115,9 +115,6 @@ public abstract class DeltaPipelineStateStoreBaseTest extends DeltaPipelineTestB
       .build();
   }
 
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-
   abstract Long getMaxGenerationNum(ApplicationId appId, String path) throws IOException;
 
   abstract OffsetAndSequence getOffset(DeltaWorkerId id, String path) throws IOException;

--- a/delta-app/src/test/java/io/cdap/delta/store/DBReplicationOffsetStoreTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/DBReplicationOffsetStoreTest.java
@@ -38,9 +38,6 @@ public class DBReplicationOffsetStoreTest extends SystemAppTestBase {
 
   private static final Gson GSON = new Gson();
 
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-
   @Before
   public void setupTest() throws Exception {
     getStructuredTableAdmin().create(DBReplicationOffsetStore.TABLE_SPEC);

--- a/delta-app/src/test/java/io/cdap/delta/store/DBReplicationStateStoreTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/DBReplicationStateStoreTest.java
@@ -34,9 +34,6 @@ import java.util.Collection;
 
 public class DBReplicationStateStoreTest extends SystemAppTestBase {
 
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-
   @Before
   public void setupTest() throws Exception {
     getStructuredTableAdmin().create(DBReplicationStateStore.TABLE_SPEC);

--- a/delta-app/src/test/java/io/cdap/delta/store/DBStateStoreServiceTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/DBStateStoreServiceTest.java
@@ -38,9 +38,6 @@ import java.util.Map;
 
 public class DBStateStoreServiceTest extends SystemAppTestBase {
 
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-
   @Before
   public void setupTest() throws Exception {
     getStructuredTableAdmin().create(DBReplicationOffsetStore.TABLE_SPEC);

--- a/delta-app/src/test/java/io/cdap/delta/store/DraftServiceTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/DraftServiceTest.java
@@ -76,9 +76,6 @@ public class DraftServiceTest extends SystemAppTestBase {
 
   private static final ConfigMacroEvaluator MACRO_EVALUATOR = new ConfigMacroEvaluator(NoOpPropertyEvaluator.INSTANCE);
 
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-
   @Before
   public void setupTest() throws Exception {
     getStructuredTableAdmin().create(DraftStore.TABLE_SPEC);

--- a/delta-app/src/test/java/io/cdap/delta/store/DraftStoreTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/store/DraftStoreTest.java
@@ -47,9 +47,6 @@ import java.util.Optional;
  */
 public class DraftStoreTest extends SystemAppTestBase {
 
-  @ClassRule
-  public static final TestConfiguration CONFIG = new TestConfiguration(Constants.Explore.EXPLORE_ENABLED, false);
-
   @Before
   public void setupTest() throws Exception {
     getStructuredTableAdmin().create(DraftStore.TABLE_SPEC);


### PR DESCRIPTION
- As part of cdapio/cdap/pull/14802, the module `cdap-explore` and its references and occurrences are removed from CDAP repository.
- Similar references in `delta` need to be removed.
[JIRA](https://cdap.atlassian.net/browse/CDAP-20224)