### PR TITLE
CDAP-20613: Add capability to log thread dump for debugability

### DIFF
--- a/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/DeltaContext.java
@@ -66,6 +66,7 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
   private long sequenceNumber;
   private final AtomicReference<Offset> committedOffset;
   private final MetricsHandler metricsHandler;
+  private final PipelineConfigService pipelineConfigService;
 
   DeltaContext(DeltaWorkerId id, String runId, Metrics metrics, StateStore stateStore,
                WorkerContext workerContext, PipelineStateService stateService,
@@ -82,7 +83,8 @@ public class DeltaContext implements DeltaSourceContext, DeltaTargetContext {
     this.sourceProperties = sourceProperties;
     this.tables = Collections.unmodifiableSet(new HashSet<>(tables));
     this.committedOffset = new AtomicReference<>(null);
-    this.metricsHandler = new MetricsHandler(id, metrics, tables, runtimeArguments);
+    this.pipelineConfigService = new PipelineConfigService(runtimeArguments);
+    this.metricsHandler = new MetricsHandler(id, metrics, tables, pipelineConfigService);
   }
 
   @Override

--- a/delta-app/src/main/java/io/cdap/delta/app/Diagnostics.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/Diagnostics.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+
+/**
+ * Used to capture and log diagnostic information for a delta worker
+ */
+public class Diagnostics {
+  private static final Logger LOG = LoggerFactory.getLogger(Diagnostics.class);
+
+  public static void logDiagnosticInfo() {
+    logThreadDump();
+  }
+
+  private static void logThreadDump() {
+    try {
+      ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+      ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(true, true);
+
+      for (ThreadInfo threadInfo : threadInfos) {
+        LOG.info("" + threadInfo);
+      }
+    } catch (Exception e) {
+      LOG.warn("Error in capturing diagnostic thread dump", e);
+    }
+  }
+}

--- a/delta-app/src/main/java/io/cdap/delta/app/Diagnostics.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/Diagnostics.java
@@ -39,7 +39,7 @@ public class Diagnostics {
       ThreadInfo[] threadInfos = threadMXBean.dumpAllThreads(true, true);
 
       for (ThreadInfo threadInfo : threadInfos) {
-        LOG.info("" + threadInfo);
+        LOG.info(threadInfo.toString());
       }
     } catch (Exception e) {
       LOG.warn("Error in capturing diagnostic thread dump", e);

--- a/delta-app/src/main/java/io/cdap/delta/app/PipelineConfigService.java
+++ b/delta-app/src/main/java/io/cdap/delta/app/PipelineConfigService.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2023 Cask Data, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.cdap.delta.app;
+
+import java.util.Map;
+
+/**
+ * Service to resolve pipeline runtime configuration
+ * Currently uses static runtime arguments, but can be enhanced
+ * to fetch dynamic runtime configuration from CDF instance
+ */
+public class PipelineConfigService {
+
+  public static final String DIAGNOSTIC_MODE_ENABLED = "diagnostic.mode.enabled";
+  public static final String AGGREGATE_STATS_FREQUENCY_ARG = "aggregate.stats.frequency.sec";
+  static final String DEFAULT_AGGR_STATS_INTERVAL_SEC = "600"; // 10 min
+
+  private final boolean diagnosticModeEnabled;
+
+  private final int logAggregateStatsIntervalSec;
+
+  public PipelineConfigService(Map<String, String> runtimeArguments) {
+
+    this.logAggregateStatsIntervalSec = Integer.parseInt(
+      runtimeArguments.getOrDefault(AGGREGATE_STATS_FREQUENCY_ARG, DEFAULT_AGGR_STATS_INTERVAL_SEC));
+
+    this.diagnosticModeEnabled = Boolean.parseBoolean(
+      runtimeArguments.getOrDefault(DIAGNOSTIC_MODE_ENABLED, "false"));
+  }
+
+  public boolean isDiagnosticModeEnabled() {
+    return diagnosticModeEnabled;
+  }
+
+  public int getLogAggregateStatsIntervalSec() {
+    return logAggregateStatsIntervalSec;
+  }
+}

--- a/delta-app/src/test/java/io/cdap/delta/app/metrics/MetricsHandlerTest.java
+++ b/delta-app/src/test/java/io/cdap/delta/app/metrics/MetricsHandlerTest.java
@@ -26,6 +26,7 @@ import io.cdap.delta.api.DMLOperation;
 import io.cdap.delta.api.DeltaPipelineId;
 import io.cdap.delta.api.SourceTable;
 import io.cdap.delta.app.DeltaWorkerId;
+import io.cdap.delta.app.PipelineConfigService;
 import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
@@ -45,7 +46,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import static io.cdap.delta.app.metrics.MetricsHandler.AGGREGATE_STATS_FREQUENCY_ARG;
+import static io.cdap.delta.app.PipelineConfigService.AGGREGATE_STATS_FREQUENCY_ARG;
 
 @RunWith(MockitoJUnitRunner.class)
 public class MetricsHandlerTest {
@@ -83,9 +84,11 @@ public class MetricsHandlerTest {
     Map<String, String> runtimeArgs = new HashMap<>();
     runtimeArgs.put(AGGREGATE_STATS_FREQUENCY_ARG, "4");
 
+    PipelineConfigService configService = new PipelineConfigService(runtimeArgs);
+
     Mockito.when(metrics.child(Mockito.any())).thenReturn(metrics);
 
-    metricsHandler = new MetricsHandler(deltaWorkerId, metrics, tables, runtimeArgs);
+    metricsHandler = new MetricsHandler(deltaWorkerId, metrics, tables, configService);
 
     metricsHandler.clearMetrics();
     listAppender.list.clear();


### PR DESCRIPTION
Thread dump is logged if
- Diagnostic mode is enabled via preference `diagnostic.mode.enabled` set to `true` (disabled by default)
- No events are processed by the target BQ plugin in a certain interval.